### PR TITLE
3.0.0 beta

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -131,55 +131,6 @@
       cursor: not-allowed!important;
     }
   }
-
-  // slider tooltip style
-  &-tooltip {
-    position: absolute;
-    left: -9999px;
-    top: -9999px;
-    z-index: 4;
-    visibility: visible;
-
-    .borderBox();
-
-    &-hidden {
-      display: none;
-    }
-
-    &-placement-top {
-      padding: @tooltip-arrow-width 0 @tooltip-distance 0;
-    }
-
-    &-inner {
-      padding: 6px 2px;
-      min-width: 24px;
-      height: 24px;
-      font-size: 12px;
-      line-height: 1;
-      color: @tooltip-color;
-      text-align: center;
-      text-decoration: none;
-      background-color: @tooltip-bg;
-      border-radius: @border-radius-base;
-      box-shadow: 0 0 4px #d9d9d9;
-    }
-
-    &-arrow {
-      position: absolute;
-      width: 0;
-      height: 0;
-      border-color: transparent;
-      border-style: solid;
-    }
-
-    &-placement-top &-arrow {
-      bottom: @tooltip-distance - @tooltip-arrow-width;
-      left: 50%;
-      margin-left: -@tooltip-arrow-width;
-      border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
-      border-top-color: @tooltip-arrow-color;
-    }
-  }
 }
 
 .motion-common() {
@@ -239,5 +190,53 @@
     opacity: 0;
     transform-origin: 50% 100%;
     transform: scale(0, 0);
+  }
+}
+
+.rc-tooltip {
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  z-index: 4;
+  visibility: visible;
+
+  .borderBox();
+
+  &-hidden {
+    display: none;
+  }
+
+  &-placement-top {
+    padding: @tooltip-arrow-width 0 @tooltip-distance 0;
+  }
+
+  &-inner {
+    padding: 6px 2px;
+    min-width: 24px;
+    height: 24px;
+    font-size: 12px;
+    line-height: 1;
+    color: @tooltip-color;
+    text-align: center;
+    text-decoration: none;
+    background-color: @tooltip-bg;
+    border-radius: @border-radius-base;
+    box-shadow: 0 0 4px #d9d9d9;
+  }
+
+  &-arrow {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+  }
+
+  &-placement-top &-arrow {
+    bottom: @tooltip-distance - @tooltip-arrow-width;
+    left: 50%;
+    margin-left: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
+    border-top-color: @tooltip-arrow-color;
   }
 }

--- a/examples/marks.js
+++ b/examples/marks.js
@@ -28,7 +28,7 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Slider with marks and steps, `included=true`</p>
-      <Slider marks={marks} step={10} defaultIndex={1} />
+      <Slider marks={marks} step={10} onChange={log} defaultIndex={1} />
     </div>
 
     <div style={style}>
@@ -46,7 +46,7 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Range with marks and steps</p>
-      <Slider range marks={marks} step={10} defaultIndex={[1,2]} />
+      <Slider range marks={marks} step={10} onChange={log} defaultIndex={[1,2]} />
     </div>
   </div>
   , document.getElementById('__react-content'));

--- a/examples/marks.js
+++ b/examples/marks.js
@@ -7,7 +7,15 @@ var ReactDOM = require('react-dom');
 var Slider = require('rc-slider');
 
 var style = {width: 400, margin: 50};
-var marks = ['A','B','C','D', 'E', 'F'];
+var marks = {
+  0: 'A',
+  20: 'B',
+  40: 'C',
+  60: 'D',
+  80: 'E',
+  100: 'F'
+};
+
 var log = function(value) {
   console.log(value);
 };

--- a/examples/marks.js
+++ b/examples/marks.js
@@ -8,12 +8,10 @@ var Slider = require('rc-slider');
 
 var style = {width: 400, margin: 50};
 var marks = {
-  0: 'A',
-  20: 'B',
-  40: 'C',
-  60: 'D',
-  80: 'E',
-  100: 'F'
+  0: '0°C',
+  26: '26°C',
+  37: '37°C',
+  100: '100°C'
 };
 
 var log = function(value) {
@@ -24,29 +22,29 @@ ReactDOM.render(
   <div>
     <div style={style}>
       <p>Slider with marks, `included=true`</p>
-      <Slider marks={marks} onChange={log} defaultIndex={1} />
+      <Slider marks={marks} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
       <p>Slider with marks and steps, `included=true`</p>
-      <Slider marks={marks} step={10} onChange={log} defaultIndex={1} />
+      <Slider marks={marks} step={10} onChange={log} defaultValue={20} />
     </div>
 
     <div style={style}>
       <p>Slider with marks, `included=false`</p>
-      <Slider marks={marks} included={false} defaultIndex={1} />
+      <Slider marks={marks} included={false} defaultValue={20} />
     </div>
     <div style={style}>
       <p>Slider with marks and steps, `included=false`</p>
-      <Slider marks={marks} step={10} included={false} defaultIndex={1} />
+      <Slider marks={marks} step={10} included={false} defaultValue={20} />
     </div>
 
     <div style={style}>
       <p>Range with marks</p>
-      <Slider range marks={marks} onChange={log} defaultIndex={[1,2]} />
+    <Slider range marks={marks} onChange={log} defaultValue={[20, 40]} />
     </div>
     <div style={style}>
       <p>Range with marks and steps</p>
-      <Slider range marks={marks} step={10} onChange={log} defaultIndex={[1,2]} />
+      <Slider range marks={marks} step={10} onChange={log} defaultValue={[20, 40]} />
     </div>
   </div>
   , document.getElementById('__react-content'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-slider",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "slider ui component for react",
   "keywords": [
     "react",

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -39,7 +39,7 @@ export default class Handle extends React.Component {
 
     const isTooltipVisible = dragging || this.state.isTooltipVisible;
     return (<Tooltip
-              prefixCls={className.replace('handle', 'tooltip')}
+              prefixCls={className.replace('slider-handle', 'tooltip')}
               placement="top"
               visible={isTooltipVisible}
               overlay={<span>{tipFormatter ? tipFormatter(value) : value}</span>}

--- a/src/Marks.jsx
+++ b/src/Marks.jsx
@@ -1,35 +1,36 @@
 import React from 'react';
 import rcUtil from 'rc-util';
 
-const Marks = ({className, marks, index, included}) => {
-  const marksLen = marks.length;
-  const unit = 100 / (marksLen - 1);
+const Marks = ({className, marks, included, upperBound, lowerBound, max, min}) => {
+  const marksKeys = Object.keys(marks);
+  const marksCount = marksKeys.length;
+  const unit = 100 / (marksCount - 1);
   const markWidth = unit / 2 + '%';
 
-  const elements = [];
-  for (let i = 0; i < marksLen; i++) {
-    const isActived = (included && i <= index) || (!included && i === index);
+  const range = max - min;
+  const elements = marksKeys.map(parseFloat).map((point) => {
+    const isActived = (!included && point === upperBound) ||
+            (included && point <= upperBound && point >= lowerBound);
     const markClassName = rcUtil.classSet({
       [className + '-text']: true,
       [className + '-text-active']: isActived,
     });
 
     const style = { width: markWidth };
-    const offset = unit * i;
-    if (i === marksLen - 1) {
+    if (point === marksCount - 1) {
       style.right = -unit / 4 + '%';
+    } else if (point === 0) {
+      style.left = -unit / 4 + '%';
     } else {
-      style.left = (i > 0 ? offset - unit / 4 : -unit / 4) + '%';
+      style.left = (point - min) / range * 100 - unit / 4 + '%';
     }
 
-    elements.push(<span className={markClassName} style={style} key={i}>
-                    {marks[i]}
-                  </span>);
-  }
+    return (<span className={markClassName} style={style} key={point}>
+             {marks[point]}
+            </span>);
+  });
 
-  return (<div className={className}>
-            {elements}
-          </div>);
+  return <div className={className}>{elements}</div>;
 };
 
 export default Marks;

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -233,9 +233,9 @@ class Slider extends React.Component {
   }
 
   getPoints() {
-    const {marks, step, dots, min, max} = this.props;
+    const {marks, step, min, max} = this.props;
     const points = new Set(Object.keys(marks));
-    if (step > 1 && dots) {
+    if (step > 1) {
       for (let i = min; i <= max; i = i + step) {
         points.add(i);
       }
@@ -262,10 +262,7 @@ class Slider extends React.Component {
   trimAlignValue(v) {
     const state = this.state || {};
     const {handle, lowerBound, upperBound} = state;
-    const props = this.props;
-    const {marks, min, max} = props;
-    const marksLen = Object.keys(marks).length;
-    const step = (marksLen > 0) ? (max - min) / (marksLen - 1) : props.step;
+    const {min, max} = this.props;
 
     let val = v;
     if (val <= min) {
@@ -281,14 +278,11 @@ class Slider extends React.Component {
       val = upperBound;
     }
 
-    const valModStep = (val - min) % step;
+    const points = this.getPoints().map(parseFloat);
+    const diffs = points.map((point) => Math.abs(val - point));
+    const closestPoint = points[diffs.indexOf(Math.min.apply(Math, diffs))];
 
-    let alignValue = val - valModStep;
-    if (Math.abs(valModStep) * 2 >= step) {
-      alignValue += (valModStep > 0) ? step : (-step);
-    }
-
-    return parseFloat(alignValue.toFixed(5));
+    return closestPoint;
   }
 
   calcOffset(value) {
@@ -310,9 +304,9 @@ class Slider extends React.Component {
   }
 
   calcValueFromIndex(index, props) {
-    const marksLen = Object.keys(props.marks).length;
-    if (marksLen > 0) {
-      const value = ((props.max - props.min) / (marksLen - 1)) * (index);
+    const marksCount = Object.keys(props.marks).length;
+    if (marksCount > 0) {
+      const value = ((props.max - props.min) / (marksCount - 1)) * (index);
       return parseFloat(value.toFixed(5));
     }
     return ('value' in props ? props.value : props.defaultValue);
@@ -367,9 +361,9 @@ class Slider extends React.Component {
 
   render() {
     const {handle, upperBound, lowerBound} = this.state;
-    const {className, prefixCls, disabled, included, range,
+    const {className, prefixCls, disabled, dots, included, range,
            marks, max, min, tipTransitionName, tipFormatter, children} = this.props;
-    const marksLen = Object.keys(marks).length;
+    const marksCount = Object.keys(marks).length;
 
     const sliderClassName = classSet({
       [prefixCls]: true,
@@ -387,7 +381,7 @@ class Slider extends React.Component {
     }
 
     const handleClassName = prefixCls + '-handle';
-    const isNoTip = (marksLen > 0) && !tipFormatter;
+    const isNoTip = (marksCount > 0) && !tipFormatter;
     const upper = (<Handle className={handleClassName} tipTransitionName={tipTransitionName} noTip={isNoTip} tipFormatter={tipFormatter}
                      offset={upperOffset} value={upperBound} dragging={handle === 'upperBound'} />);
 
@@ -405,7 +399,7 @@ class Slider extends React.Component {
         {track}
         {upper}
         {lower}
-        <Steps prefixCls={prefixCls} points={this.getPoints()}
+        <Steps prefixCls={prefixCls} points={this.getPoints()} dots={dots}
                included={isIncluded} lowerBound={lowerBound}
                upperBound={upperBound} max={max} min={min} />
         <Marks className={prefixCls + '-mark'} marks={marks}

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -127,10 +127,10 @@ class Slider extends React.Component {
     // If it is not controlled component
     if (!('value' in props) && !('index' in props)) {
       this.setState({[state.handle]: value}, () => {
-        this.triggerEvents('onChange', this.getValue());
+        props.onChange(this.getValue());
       });
     } else {
-      this.triggerEvents('onChange', this.getChangedValue(state.handle, value));
+      props.onChange(this.getChangedValue(state.handle, value));
     }
   }
 
@@ -151,7 +151,8 @@ class Slider extends React.Component {
   }
 
   onStart(position) {
-    this.triggerEvents('onBeforeChange', this.getValue());
+    const props = this.props;
+    props.onBeforeChange(this.getValue());
 
     const value = this.calcValueByPos(position);
     this.startValue = value;
@@ -185,16 +186,15 @@ class Slider extends React.Component {
     const oldValue = state[valueNeedChanging];
     if (value === oldValue) return;
 
-    const props = this.props;
     // If it is not controlled component
     if (!('value' in props) && !('index' in props)) {
       this.setState({
         [valueNeedChanging]: value,
       }, () => {
-        this.triggerEvents('onChange', this.getValue());
+        props.onChange(this.getValue());
       });
     } else {
-      this.triggerEvents('onChange', this.getChangedValue(valueNeedChanging, value));
+      props.onChange(this.getChangedValue(valueNeedChanging, value));
     }
   }
 
@@ -315,26 +315,6 @@ class Slider extends React.Component {
     return ('value' in props ? props.value : props.defaultValue);
   }
 
-  triggerEvents(event, v) {
-    const props = this.props;
-    const hasMarks = !isEmpty(props.marks);
-    if (props[event]) {
-      let data;
-      if (hasMarks) {
-        if (props.range) {
-          data = v.map(bound => this.getIndex(bound));
-        } else {
-          data = this.getIndex(v);
-        }
-      } else if (v === undefined) {
-        data = this.state.value;
-      } else {
-        data = v;
-      }
-      props[event](data);
-    }
-  }
-
   addDocumentEvents(type) {
     if (type === 'touch') {
       // just work for chrome iOS Safari and Android Browser
@@ -358,7 +338,7 @@ class Slider extends React.Component {
 
   end(type) {
     this.removeEventons(type);
-    this.triggerEvents('onAfterChange', this.getValue());
+    this.props.onAfterChange(this.getValue());
     this.setState({handle: null});
   }
 
@@ -450,16 +430,19 @@ Slider.propTypes = {
 };
 
 Slider.defaultProps = {
+  prefixCls: 'rc-slider',
+  className: '',
+  tipTransitionName: '',
   min: 0,
   max: 100,
   step: 1,
-  defaultIndex: 0,
+  defaultIndex: 0, // TODO
   marks: {},
+  onBeforeChange: noop,
+  onChange: noop,
+  onAfterChange: noop,
   included: true,
-  className: '',
-  prefixCls: 'rc-slider',
   disabled: false,
-  tipTransitionName: '',
   dots: false,
   range: false,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -352,7 +352,7 @@ class Slider extends React.Component {
 
   render() {
     const {handle, upperBound, lowerBound} = this.state;
-    const {className, prefixCls, disabled, included, isIncluded, dots, range,
+    const {className, prefixCls, disabled, included, dots, range,
            marks, step, max, min, tipTransitionName, tipFormatter, children} = this.props;
     const marksLen = marks.length;
 
@@ -366,7 +366,7 @@ class Slider extends React.Component {
     const lowerOffset = this.calcOffset(lowerBound);
 
     let track = null;
-    if ((included && isIncluded) || range) {
+    if (included || range) {
       const trackClassName = prefixCls + '-track';
       track = <Track className={trackClassName} offset={lowerOffset} length={upperOffset - lowerOffset}/>;
     }
@@ -390,14 +390,14 @@ class Slider extends React.Component {
       const stepNum = marksLen > 0 ? marksLen : Math.floor((max - min) / step) + 1;
       steps = (<Steps className={stepsClassName} stepNum={stepNum}
                       lowerIndex={this.getIndex(lowerBound)} upperIndex={upperIndex}
-                      included={(included && isIncluded) || range}/>);
+                      included={included || range}/>);
     }
 
     let mark = null;
     if (marksLen > 0) {
       const markClassName = prefixCls + '-mark';
       mark = (<Marks className={markClassName} marks={marks}
-                     index={upperIndex} included={(included && isIncluded)}/>);
+                     index={upperIndex} included={included}/>);
     }
 
     return (
@@ -436,7 +436,6 @@ Slider.propTypes = {
     React.PropTypes.arrayOf(React.PropTypes.number),
   ]),
   marks: React.PropTypes.array,
-  isIncluded: React.PropTypes.bool, // @Deprecated
   included: React.PropTypes.bool,
   className: React.PropTypes.string,
   prefixCls: React.PropTypes.string,
@@ -457,7 +456,6 @@ Slider.defaultProps = {
   step: 1,
   defaultIndex: 0,
   marks: [],
-  isIncluded: true, // @Deprecated
   included: true,
   className: '',
   prefixCls: 'rc-slider',

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -88,19 +88,17 @@ class Slider extends React.Component {
     const props = this.props;
     const isNotControlled = !('value' in props);
     if (isNotControlled) {
-      this.setState({[handle]: value}, () => {
-        props.onChange(this.getValue());
-      });
-    } else {
-      const state = this.state;
-      const data = {
-        upperBound: state.upperBound,
-        lowerBound: state.lowerBound,
-      };
-      data[handle] = value;
-      const changedValue = props.range ? [data.lowerBound, data.upperBound] : data.upperBound;
-      props.onChange(changedValue);
+      this.setState({[handle]: value});
     }
+
+    const state = this.state;
+    const data = {
+      upperBound: state.upperBound,
+      lowerBound: state.lowerBound,
+    };
+    data[handle] = value;
+    const changedValue = props.range ? [data.lowerBound, data.upperBound] : data.upperBound;
+    props.onChange(changedValue);
   }
 
   onMouseMove(e) {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -182,6 +182,9 @@ class Slider extends React.Component {
       recent: valueNeedChanging,
     });
 
+    const oldValue = state[valueNeedChanging];
+    if (value === oldValue) return;
+
     const props = this.props;
     // If it is not controlled component
     if (!('value' in props) && !('index' in props)) {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -235,7 +235,7 @@ class Slider extends React.Component {
   getPoints() {
     const {marks, step, min, max} = this.props;
     const points = new Set(Object.keys(marks));
-    if (step > 1) {
+    if (isEmpty(marks) || step > 1) {
       for (let i = min; i <= max; i = i + step) {
         points.add(i);
       }

--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { classSet } from 'rc-util';
 
-const Steps = ({prefixCls, points, included, lowerBound, upperBound, max, min}) => {
+const Steps = ({prefixCls, points, dots, included, lowerBound, upperBound, max, min}) => {
   const range = max - min;
-  const elements = points.map(parseFloat).map((point) => {
-    const offset = (point - min) / range * 100 + '%';
-    const style = { left: offset };
+  const elements = points.filter((point) => typeof point === 'string' || dots).map(parseFloat)
+          .map((point) => {
+            const offset = (point - min) / range * 100 + '%';
+            const style = { left: offset };
 
-    const isActived = (!included && point === upperBound) ||
-            (included && point <= upperBound && point >= lowerBound);
-    const pointClassName = classSet({
-      [prefixCls + '-dot']: true,
-      [prefixCls + '-dot-active']: isActived,
-    });
+            const isActived = (!included && point === upperBound) ||
+                    (included && point <= upperBound && point >= lowerBound);
+            const pointClassName = classSet({
+              [prefixCls + '-dot']: true,
+              [prefixCls + '-dot-active']: isActived,
+            });
 
-    return <span className={pointClassName} style={style} key={point} />;
-  });
+            return <span className={pointClassName} style={style} key={point} />;
+          });
 
   return <div className={prefixCls + '-step'}>{elements}</div>;
 };

--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -1,28 +1,23 @@
 import React from 'react';
-import rcUtil from 'rc-util';
+import { classSet } from 'rc-util';
 
-const Steps = ({className, stepNum, included, lowerIndex, upperIndex}) => {
-  const dotClassName = className.replace('step', 'dot');
-  const unit = 100 / (stepNum - 1);
-
-  const elements = [];
-  for (let i = 0; i < stepNum; i++) {
-    const offset = unit * i + '%';
+const Steps = ({prefixCls, points, included, lowerBound, upperBound, max, min}) => {
+  const range = max - min;
+  const elements = points.map(parseFloat).map((point) => {
+    const offset = (point - min) / range * 100 + '%';
     const style = { left: offset };
 
-    const isActived = (included && i <= upperIndex && i >= lowerIndex ) ||
-            (!included && i === upperIndex);
-    const stepClassName = rcUtil.classSet({
-      [dotClassName]: true,
-      [dotClassName + '-active']: isActived,
+    const isActived = (!included && point === upperBound) ||
+            (included && point <= upperBound && point >= lowerBound);
+    const pointClassName = classSet({
+      [prefixCls + '-dot']: true,
+      [prefixCls + '-dot-active']: isActived,
     });
 
-    elements.push(<span className={stepClassName} style={style} key={i} />);
-  }
+    return <span className={pointClassName} style={style} key={point} />;
+  });
 
-  return (<div className={className}>
-            {elements}
-          </div>);
+  return <div className={prefixCls + '-step'}>{elements}</div>;
 };
 
 export default Steps;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -52,17 +52,17 @@ describe('rc-slider', function () {
 
   it('should render a slider with marks correctly!', function () {
     var slider = ReactDOM.render(
-      <Slider marks={["一","二","三","四","五"]} defaultIndex={3} />,
+      <Slider marks={{0: "一", 20: "二", 40: "三", 60: "四", 100: "五"}} defaultValue={40} />,
       div
     );
     var node = $(div);
     expect(node.find('.rc-slider').length).to.be(1);
     expect(node.find('.rc-slider-handle').length).to.be(1);
     expect(node.find('.rc-slider-track').length).to.be(1);
-    expect(node.find('.rc-slider-dot').length).to.be(slider.props.marks.length);
+    expect(node.find('.rc-slider-dot').length).to.be(Object.keys(slider.props.marks).length);
     expect(node.find('.rc-slider-mark').length).to.be(1);
-    expect(node.find('.rc-slider-mark-text').length).to.be(slider.props.marks.length);
-    expect(slider.getIndex(slider.state.upperBound)).to.be(3);
+    expect(node.find('.rc-slider-mark-text').length).to.be(Object.keys(slider.props.marks).length);
+    expect(slider.state.upperBound).to.be(40);
   });
 
   // it('should mouseDown works!', function (done) {


### PR DESCRIPTION
这个 PR 依赖于之前提交的 https://github.com/react-component/slider/pull/40

不兼容的修改主要有两点：

1. 移除了之前 deprecated 的 `isIncluded` `withDots`
1. 解绑 `marks` 和 `step`，现在 `marks` 是一个 Object 其中 key 为 `Number`，value 为 `String`

antd 那边稍后会做一层包装，以兼容旧版。

Close: https://github.com/react-component/slider/issues/26
