### PR TITLE
reduce gaps between marks

### DIFF
--- a/src/Marks.jsx
+++ b/src/Marks.jsx
@@ -5,7 +5,7 @@ const Marks = ({className, marks, included, upperBound, lowerBound, max, min}) =
   const marksKeys = Object.keys(marks);
   const marksCount = marksKeys.length;
   const unit = 100 / (marksCount - 1);
-  const markWidth = unit / 2 + '%';
+  const markWidth = unit * 0.9;
 
   const range = max - min;
   const elements = marksKeys.map(parseFloat).map((point) => {
@@ -16,8 +16,8 @@ const Marks = ({className, marks, included, upperBound, lowerBound, max, min}) =
       [className + '-text-active']: isActived,
     });
 
-    const style = { width: markWidth };
-    style.left = (point - min) / range * 100 - unit / 4 + '%';
+    const style = { width: markWidth + '%' };
+    style.left = (point - min) / range * 100 - markWidth / 2 + '%';
 
     return (<span className={markClassName} style={style} key={point}>
              {marks[point]}


### PR DESCRIPTION
Now even short enough labels can't fit into one string.

I have this in my app:
![screen shot 2015-11-23 at 00 19 46](https://cloud.githubusercontent.com/assets/812240/11326331/12a09774-9178-11e5-9890-0bd49250bd99.png)

With my fix, it would be better. Borders are especially have been added to show mark constraints:

![screen shot 2015-11-23 at 00 34 56](https://cloud.githubusercontent.com/assets/812240/11326408/123a70c8-917a-11e5-859e-2a2e8a596097.png)