### PR TITLE
If tipFormatter is null, don't show the tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ ReactDOM.render(<Rcslider />, container);
         </tr>
         <tr>
           <td>tipFormatter</td>
-          <td>function</td>
+          <td>function or `null`</td>
           <td></td>
-          <td>Format the value of the tooltip if it shows.</td>
+          <td>Format the value of the tooltip if it shows. If `null` the tooltip will always be hidden.</td>
         </tr>
         <tr>
           <td>dots</td>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -87,6 +87,10 @@ ReactDOM.render(
       <Slider tipFormatter={percentFormatter} tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} />
     </div>
     <div style={style}>
+      <p>Basic Slider without tooltip</p>
+      <Slider tipFormatter={null} onChange={log} />
+    </div>
+    <div style={style}>
       <p>Controlled Slider</p>
       <Slider value={50} />
     </div>

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -339,7 +339,7 @@ class Slider extends React.Component {
     const lowerOffset = this.calcOffset(lowerBound);
 
     const handleClassName = prefixCls + '-handle';
-    const isNoTip = tipFormatter === null || (step === null && !tipFormatter);
+    const isNoTip = (step === null) || (tipFormatter === null);
 
     const upper = (<Handle className={handleClassName}
                            noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -339,7 +339,7 @@ class Slider extends React.Component {
     const lowerOffset = this.calcOffset(lowerBound);
 
     const handleClassName = prefixCls + '-handle';
-    const isNoTip = (step === null) && !tipFormatter;
+    const isNoTip = tipFormatter === null || (step === null && !tipFormatter);
 
     const upper = (<Handle className={handleClassName}
                            noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}


### PR DESCRIPTION
We're using this component in an application where we display the actual value of the slider in a separate text box. We didn't want to show the tip in this case but there didn't seem to be any way to simply hide it. I thought setting the tipFormatter prop to null would be a sensible way to force the tip to be hidden.