### PR TITLE
ReverseSlide function added, small Dots bug fixed

### DIFF
--- a/src/Dots.jsx
+++ b/src/Dots.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 function calcPoints(marks, dots, step, min, max) {
   const points = Object.keys(marks).map(parseFloat);
-  if (dots) {
+  if (dots && step) {
     for (let i = min; i <= max; i = i + step) {
       if (points.indexOf(i) >= 0) continue;
       points.push(i);
@@ -13,6 +13,7 @@ function calcPoints(marks, dots, step, min, max) {
 }
 
 const Dots = ({prefixCls, marks, dots, step, included, lowerBound, upperBound, max, min}) => {
+  if (!dots) return <div></div>;
   const range = max - min;
   const elements = calcPoints(marks, dots, step, min, max).map((point) => {
     const offset = (point - min) / range * 100 + '%';

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -103,6 +103,47 @@ describe('rc-slider', function() {
     expect(trackStyle).to.match(/visibility: visible;/);
   });
 
+  it('should render a reverseSlide with correct DOM structure', () => {
+    const reverseSlide = ReactDOM.render(<Slider reverseSlide />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlide, 'rc-slider').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlide, 'rc-slider-handle').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlide, 'rc-slider-track').length).to.be(1);
+  });
+
+  it('should render a reverseSlide with default value correctly', () => {
+    const reverseSlideWithDefaultValue = ReactDOM.render(<Slider reverseSlide defaultValue={50} />, div);
+    expect(reverseSlideWithDefaultValue.state.lowerBound).to.be(50);
+    expect(reverseSlideWithDefaultValue.state.upperBound).to.be(100);
+    expect(ReactTestUtils
+           .scryRenderedDOMComponentsWithClass(reverseSlideWithDefaultValue, 'rc-slider-handle')[0]
+           .style.cssText)
+      .to.match(/left: 50%;/);
+
+    const trackStyle = ReactTestUtils
+            .scryRenderedDOMComponentsWithClass(reverseSlideWithDefaultValue, 'rc-slider-track')[0]
+            .style.cssText;
+    expect(trackStyle).to.match(/left: 50%;/);
+    expect(trackStyle).to.match(/width: 50%;/);
+    expect(trackStyle).to.match(/visibility: visible;/);
+  });
+
+  it('should render a reverseSlide with value correctly', () => {
+    const reverseSlideWithValue = ReactDOM.render(<Slider reverseSlide value={50} />, div);
+    expect(reverseSlideWithValue.state.lowerBound).to.be(50);
+    expect(reverseSlideWithValue.state.upperBound).to.be(100);
+    expect(ReactTestUtils
+           .scryRenderedDOMComponentsWithClass(reverseSlideWithValue, 'rc-slider-handle')[0]
+           .style.cssText)
+      .to.match(/left: 50%;/);
+
+    const trackStyle = ReactTestUtils
+            .scryRenderedDOMComponentsWithClass(reverseSlideWithValue, 'rc-slider-track')[0]
+            .style.cssText;
+    expect(trackStyle).to.match(/left: 50%;/);
+    expect(trackStyle).to.match(/width: 50%;/);
+    expect(trackStyle).to.match(/visibility: visible;/);
+  });
+
   it('should render dots correctly when `dots=true`', () => {
     const slider = ReactDOM.render(<Slider value={50} step={10} dots />, div);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-dot').length).to.be(11);
@@ -111,6 +152,25 @@ describe('rc-slider', function() {
     const range = ReactDOM.render(<Slider range value={[20, 50]} step={10} dots />, div);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-dot').length).to.be(11);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-dot-active').length).to.be(4);
+
+    const reverseSlide = ReactDOM.render(<Slider reverseSlide value={50} step={10} dots />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlide, 'rc-slider-dot').length).to.be(11);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlide, 'rc-slider-dot-active').length).to.be(6);
+    ReactDOM.unmountComponentAtNode(div);
+
+    const marks = {0: '0', 20: '20', 50: '50', 100: '100'};
+    const sliderWithMarksAndDots = ReactDOM.render(<Slider value={20} step={null} marks={marks} dots />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(sliderWithMarksAndDots, 'rc-slider-dot').length).to.be(4);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(sliderWithMarksAndDots, 'rc-slider-dot-active').length).to.be(2);
+
+    const rangeWithMarksAndDots = ReactDOM.render(<Slider range value={[20, 50]} step={null} marks={marks} dots />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(rangeWithMarksAndDots, 'rc-slider-dot').length).to.be(4);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(rangeWithMarksAndDots, 'rc-slider-dot-active').length).to.be(2);
+
+    const reverseSlideWithMarksAndDots = ReactDOM.render(<Slider reverseSlide value={20} step={null} marks={marks} dots />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlideWithMarksAndDots, 'rc-slider-dot').length).to.be(4);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlideWithMarksAndDots, 'rc-slider-dot-active').length).to.be(3);
+    ReactDOM.unmountComponentAtNode(div);
   });
 
   it('should render marks correctly when `marks` is not an empty object', () => {
@@ -124,6 +184,11 @@ describe('rc-slider', function() {
 
     const range = ReactDOM.render(<Slider range value={[0, 30]} marks={marks} />, div);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-mark-text').length).to.be(3);
+
+    const marks2 = {0: '0', 20: '20', 50: '50', 100: '100'};
+    const reverseSlideWithMarks = ReactDOM.render(<Slider reverseSlide marks={marks2} value={20} min={0} max={100} />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(reverseSlideWithMarks, 'rc-slider-mark-text').length).to.be(4);
+    ReactDOM.unmountComponentAtNode(div);
   });
 
   it('should not set value greater than `max` or smaller `min`', () => {
@@ -138,6 +203,11 @@ describe('rc-slider', function() {
     const range = ReactDOM.render(<Slider range value={[0, 100]} min={10} max={90} />, div);
     expect(range.state.lowerBound).to.be(10);
     expect(range.state.upperBound).to.be(90);
+    ReactDOM.unmountComponentAtNode(div);
+
+    const reverseSlide = ReactDOM.render(<Slider reverseSlide value={0} min={10} max={90} />, div);
+    expect(reverseSlide.state.lowerBound).to.be(10);
+    expect(reverseSlide.state.upperBound).to.be(90);
     ReactDOM.unmountComponentAtNode(div);
   });
 });


### PR DESCRIPTION
ReverseSlide: Allows the slider to be tethered on the right and dragged
from the left.
Dots bug: When `step=null` while `dots=true` the Dots code breaks your
browser by trying to add null. Also, dots are added even when
`dots=false` if you pass marks as a param to the slider. I have fixed
both of these issues.