### PR TITLE
tooltipAlwaysVisible prop added

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>If `true`, handles can't be moved.</td>
         </tr>
         <tr>
+          <td>tooltipAlwaysVisible</td>
+          <td>bool</td>
+          <td>false</td>
+          <td>Makes tooltip always visible.</td>
+        </tr>
+        <tr>
           <td>tipTransitionName</td>
           <td>string</td>
           <td>''</td>

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -24,7 +24,7 @@ export default class Handle extends React.Component {
 
   render() {
     const props = this.props;
-    const {className, tipTransitionName, tipFormatter, offset, value} = props;
+    const {className, tipTransitionName, tipFormatter, offset, value, tooltipAlwaysVisible} = props;
     const {dragging, noTip} = props;
 
     const style = { left: offset + '%' };
@@ -41,7 +41,7 @@ export default class Handle extends React.Component {
     return (<Tooltip
               prefixCls={className.replace('slider-handle', 'tooltip')}
               placement="top"
-              visible={isTooltipVisible}
+              visible={isTooltipVisible || tooltipAlwaysVisible}
               overlay={<span>{tipFormatter(value)}</span>}
               delay={0}
               transitionName={tipTransitionName}>
@@ -58,4 +58,5 @@ Handle.propTypes = {
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,
   noTip: React.PropTypes.bool,
+  tooltipAlwaysVisible: React.PropTypes.bool,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -333,21 +333,20 @@ class Slider extends React.Component {
   render() {
     const {handle, upperBound, lowerBound} = this.state;
     const {className, prefixCls, disabled, dots, included, range, step,
-      marks, max, min, tipTransitionName, tipFormatter, children} = this.props;
+      marks, max, min, tipTransitionName, tipFormatter, children, tooltipAlwaysVisible} = this.props;
 
     const upperOffset = this.calcOffset(upperBound);
     const lowerOffset = this.calcOffset(lowerBound);
 
     const handleClassName = prefixCls + '-handle';
     const isNoTip = (step === null) || (tipFormatter === null);
-
-    const upper = (<Handle className={handleClassName}
+    const upper = (<Handle className={handleClassName} tooltipAlwaysVisible={tooltipAlwaysVisible}
                            noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}
                            offset={upperOffset} value={upperBound} dragging={handle === 'upperBound'}/>);
 
     let lower = null;
     if (range) {
-      lower = (<Handle className={handleClassName}
+      lower = (<Handle className={handleClassName} tooltipAlwaysVisible={tooltipAlwaysVisible}
                        noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}
                        offset={lowerOffset} value={lowerBound} dragging={handle === 'lowerBound'}/>);
     }
@@ -404,6 +403,7 @@ Slider.propTypes = {
   dots: React.PropTypes.bool,
   range: React.PropTypes.bool,
   allowCross: React.PropTypes.bool,
+  tooltipAlwaysVisible: React.PropTypes.bool,
 };
 
 Slider.defaultProps = {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -126,6 +126,11 @@ describe('rc-slider', function() {
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-mark-text').length).to.be(3);
   });
 
+  it('should render with tooltip visible', () => {
+    ReactDOM.render(<Slider value={50} step={10} tooltipAlwaysVisible/>, div);
+    expect(document.getElementsByClassName('rc-tooltip').length).to.be(1);
+  });
+
   it('should not set value greater than `max` or smaller `min`', () => {
     const sliderWithMin = ReactDOM.render(<Slider value={0} min={10} />, div);
     expect(sliderWithMin.state.upperBound).to.be(10);


### PR DESCRIPTION
Setting tooltipAlwaysVisible on true makes tooltip always visible. Useful for specific designs.