### PR TITLE
Added ability to override mark styling/positioning.

### DIFF
--- a/src/Marks.jsx
+++ b/src/Marks.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const Marks = ({className, marks, included, upperBound, lowerBound, max, min}) => {
+const Marks = ({className, marks, included, upperBound, lowerBound, max, min, markStyler}) => {
   const marksKeys = Object.keys(marks);
   const marksCount = marksKeys.length;
   const unit = 100 / (marksCount - 1);
   const markWidth = unit * 0.9;
 
   const range = max - min;
-  const elements = marksKeys.map(parseFloat).sort((a, b) => a - b).map((point) => {
+  const elements = marksKeys.map(parseFloat).sort((a, b) => a - b).map((point, index) => {
     const isActived = (!included && point === upperBound) ||
             (included && point <= upperBound && point >= lowerBound);
     const markClassName = classNames({
@@ -16,10 +16,12 @@ const Marks = ({className, marks, included, upperBound, lowerBound, max, min}) =
       [className + '-text-active']: isActived,
     });
 
-    const style = { width: markWidth + '%' };
-    style.left = (point - min) / range * 100 - markWidth / 2 + '%';
-
-    return (<span className={markClassName} style={style} key={point}>
+    const defaultStyle = {
+      width: markWidth + '%',
+      left: (point - min) / range * 100 - markWidth / 2 + '%',
+    };
+    const style = markStyler ? markStyler(index, marksCount, point, defaultStyle) : defaultStyle;
+    return (<span className={markClassName} style={style || defaultStyle} key={point}>
              {marks[point]}
             </span>);
   });

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -333,7 +333,7 @@ class Slider extends React.Component {
   render() {
     const {handle, upperBound, lowerBound} = this.state;
     const {className, prefixCls, disabled, dots, included, range, step,
-      marks, max, min, tipTransitionName, tipFormatter, children} = this.props;
+      marks, max, min, tipTransitionName, tipFormatter, children, markStyler} = this.props;
 
     const upperOffset = this.calcOffset(upperBound);
     const lowerOffset = this.calcOffset(lowerBound);
@@ -371,7 +371,7 @@ class Slider extends React.Component {
               upperBound={upperBound} max={max} min={min}/>
         <Marks className={prefixCls + '-mark'} marks={marks}
                included={isIncluded} lowerBound={lowerBound}
-               upperBound={upperBound} max={max} min={min}/>
+               upperBound={upperBound} max={max} min={min} markStyler={markStyler}/>
         {children}
       </div>
     );
@@ -404,6 +404,7 @@ Slider.propTypes = {
   dots: React.PropTypes.bool,
   range: React.PropTypes.bool,
   allowCross: React.PropTypes.bool,
+  markStyler: React.PropTypes.func,
 };
 
 Slider.defaultProps = {


### PR DESCRIPTION
I had a need to modify the positioning of the min/max marks, which is applied as an inline style and not override-able via stylesheet classes. So I implemented a simple callback that will allow you to specify/calculate/override the inline styles for individual marks. Should help with #76 and #50. 

Example:
```js
function markStyler(index, marksCount, point, defaultStyle){
    if (index === 0){
      return {width: defaultStyle.width, left: 0};
    }
    if (index === marksCount - 1){
      return {width: defaultStyle.width, right: 0, left: "initial"};
    }
    return defaultStyle;
  }

```html
<Slider min={-10} marks={marks} step={null} onChange={log} defaultValue={20} markStyler={markStyler} />
```

Thanks for the great component!