### PR TITLE
avoid infinite loop when passing in dots with no step

### DIFF
--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 function calcPoints(vertical, marks, dots, step, min, max) {
   const points = Object.keys(marks).map(parseFloat);
-  if (dots) {
+  if (dots && step) {
     for (let i = min; i <= max; i = i + step) {
       if (points.indexOf(i) >= 0) continue;
       points.push(i);


### PR DESCRIPTION
I mistakenly passed in dots with no steps and it caused an infinite loop while rendering.

I know you're not supposed to use this config, but I feel this should be avoided altogether.