### PR TITLE
Allow to pass custom handle components

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>Set current positions of handles. If range is `false`, the type of `defaultValue` should be `number`. Otherwise, `[number, number]`</td>
         </tr>
         <tr>
+          <td>handle</td>
+          <td>Component</td>
+          <td></td>
+          <td>Provide a custom Handle to use in the slider by passing a component. This component will have a `value` and `offset` props used to define custom styling/content.</td>
+        </tr>
+        <tr>
           <td>included</td>
           <td>boolean</td>
           <td>true</td>

--- a/examples/custom-handles.html
+++ b/examples/custom-handles.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/custom-handles.js
+++ b/examples/custom-handles.js
@@ -1,0 +1,44 @@
+require('rc-slider/assets/index.less');
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Slider = require('rc-slider');
+
+const wrapperStyle = {width: 400, margin: 50};
+
+const handleStyle = {
+  position: 'absolute',
+  transform: 'translate(-50%, -50%)',
+  cursor: 'pointer',
+  padding: '2px',
+  border: '2px solid #abe2fb',
+  borderRadius: '3px',
+  background: '#fff',
+  fontSize: '14px',
+  textAlign: 'center',
+  zIndex: 3,
+};
+
+const CustomHandle = props => {
+  const style = Object.assign({left: props.offset + '%'}, handleStyle);
+  return (
+    <div style={style}>val: {props.value}</div>
+  );
+};
+CustomHandle.propTypes = {
+  value: React.PropTypes.any,
+  offset: React.PropTypes.number,
+};
+
+ReactDOM.render(
+  <div>
+    <div style={wrapperStyle}>
+      <p>Default slider</p>
+      <Slider min={0} max={20} defaultValue={3} />
+    </div>
+    <div style={wrapperStyle}>
+      <p>Slider with custom handle</p>
+      <Slider min={0} max={20} defaultValue={3} Handle={<CustomHandle />} />
+    </div>
+  </div>
+  , document.getElementById('__react-content'));

--- a/examples/custom-handles.js
+++ b/examples/custom-handles.js
@@ -38,7 +38,7 @@ ReactDOM.render(
     </div>
     <div style={wrapperStyle}>
       <p>Slider with custom handle</p>
-      <Slider min={0} max={20} defaultValue={3} Handle={<CustomHandle />} />
+      <Slider min={0} max={20} defaultValue={3} handle={<CustomHandle />} />
     </div>
   </div>
   , document.getElementById('__react-content'));

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -328,7 +328,9 @@ class Slider extends React.Component {
   render() {
     const {handle, upperBound, lowerBound} = this.state;
     const {className, prefixCls, disabled, vertical, dots, included, range, step,
-      marks, max, min, Handle, tipTransitionName, tipFormatter, children} = this.props;
+      marks, max, min, tipTransitionName, tipFormatter, children} = this.props;
+
+    const customHandle = this.props.handle;
 
     const upperOffset = this.calcOffset(upperBound);
     const lowerOffset = this.calcOffset(lowerBound);
@@ -336,13 +338,13 @@ class Slider extends React.Component {
     const handleClassName = prefixCls + '-handle';
     const isNoTip = (step === null) || (tipFormatter === null);
 
-    const upper = cloneElement(Handle, { className: handleClassName,
+    const upper = cloneElement(customHandle, { className: handleClassName,
         noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
         vertical: vertical, offset: upperOffset, value: upperBound, dragging: handle === 'upperBound' });
 
     let lower = null;
     if (range) {
-      lower = cloneElement(Handle, { className: handleClassName,
+      lower = cloneElement(customHandle, { className: handleClassName,
         noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
         vertical: vertical, offset: lowerOffset, value: lowerBound, dragging: handle === 'lowerBound' });
     }
@@ -395,7 +397,7 @@ Slider.propTypes = {
   onBeforeChange: React.PropTypes.func,
   onChange: React.PropTypes.func,
   onAfterChange: React.PropTypes.func,
-  Handle: React.PropTypes.element,
+  handle: React.PropTypes.element,
   tipTransitionName: React.PropTypes.string,
   tipFormatter: React.PropTypes.func,
   dots: React.PropTypes.bool,
@@ -412,7 +414,7 @@ Slider.defaultProps = {
   max: 100,
   step: 1,
   marks: {},
-  Handle: <DefaultHandle />,
+  handle: <DefaultHandle />,
   onBeforeChange: noop,
   onChange: noop,
   onAfterChange: noop,

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import {Dom as DomUtils} from 'rc-util';
 import classNames from 'classnames';
 import Track from './Track';
-import Handle from './Handle';
+import DefaultHandle from './Handle';
 import Steps from './Steps';
 import Marks from './Marks';
 
@@ -328,7 +328,7 @@ class Slider extends React.Component {
   render() {
     const {handle, upperBound, lowerBound} = this.state;
     const {className, prefixCls, disabled, vertical, dots, included, range, step,
-      marks, max, min, tipTransitionName, tipFormatter, children} = this.props;
+      marks, max, min, Handle, tipTransitionName, tipFormatter, children} = this.props;
 
     const upperOffset = this.calcOffset(upperBound);
     const lowerOffset = this.calcOffset(lowerBound);
@@ -336,15 +336,15 @@ class Slider extends React.Component {
     const handleClassName = prefixCls + '-handle';
     const isNoTip = (step === null) || (tipFormatter === null);
 
-    const upper = (<Handle className={handleClassName}
-                           noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}
-                           vertical = {vertical} offset={upperOffset} value={upperBound} dragging={handle === 'upperBound'}/>);
+    const upper = cloneElement(Handle, { className: handleClassName,
+        noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
+        vertical: vertical, offset: upperOffset, value: upperBound, dragging: handle === 'upperBound' });
 
     let lower = null;
     if (range) {
-      lower = (<Handle className={handleClassName}
-                       noTip={isNoTip} tipTransitionName={tipTransitionName} tipFormatter={tipFormatter}
-                       vertical = {vertical} offset={lowerOffset} value={lowerBound} dragging={handle === 'lowerBound'}/>);
+      lower = cloneElement(Handle, { className: handleClassName,
+        noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
+        vertical: vertical, offset: lowerOffset, value: lowerBound, dragging: handle === 'lowerBound' });
     }
 
     const sliderClassName = classNames({
@@ -395,6 +395,7 @@ Slider.propTypes = {
   onBeforeChange: React.PropTypes.func,
   onChange: React.PropTypes.func,
   onAfterChange: React.PropTypes.func,
+  Handle: React.PropTypes.element,
   tipTransitionName: React.PropTypes.string,
   tipFormatter: React.PropTypes.func,
   dots: React.PropTypes.bool,
@@ -411,6 +412,7 @@ Slider.defaultProps = {
   max: 100,
   step: 1,
   marks: {},
+  Handle: <DefaultHandle />,
   onBeforeChange: noop,
   onChange: noop,
   onAfterChange: noop,


### PR DESCRIPTION
This is my attempt to solve #63  starting from #68 

It's basically the same, I changed the API in order to pass the custom handle directly as prop, using internally `cloneElement` instead of the function, as suggested by @yiminghe 

As shown in the example:
```javascript
<Slider Handle={<MyHandle />} />
```
which I agree is much more customizable

Let me know, and in case, I guess we just need to update the docs