### PR TITLE
Ignore right button on mousedown

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -167,6 +167,7 @@ class Slider extends React.Component {
   }
 
   onMouseDown(e) {
+    if (e.button !== 0) { return; }
     const position = getMousePosition(this.props.vertical, e);
     this.onStart(position);
     this.addDocumentEvents('mouse');


### PR DESCRIPTION
Not sure if this is something that you are interested in, but I wanted it for a project, so I though I would at least try to nudge it back upstream.

Basically the issue is that if you right click on the slider (opening the context menu), you either did so for a reason other than to modify the slider value, or it was an accident altogether, so it should probably be ignored.

I tried to write a test for this with `Simulate.mouseDown` using `ReactTestUtils`, but I wasn't able to get `Simulate.mouseDown` to actual trigger `onMouseDown` on the `Slider`. If you want a test for this and have a suggestion on how to accomplish one, I'm happy to go back and try again.