### PR TITLE
Ranges: Make the value of the opposing handle available.

### DIFF
--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -57,6 +57,7 @@ Handle.propTypes = {
   tipTransitionName: React.PropTypes.string,
   tipFormatter: React.PropTypes.func,
   value: React.PropTypes.number,
+  otherValue: React.PropTypes.number,
   dragging: React.PropTypes.bool,
   noTip: React.PropTypes.bool,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -352,13 +352,15 @@ class Slider extends React.Component {
 
     const upper = cloneElement(customHandle, { className: upperClassName,
         noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
-        vertical: vertical, offset: upperOffset, value: upperBound, dragging: handle === 'upperBound' });
+        vertical: vertical, offset: upperOffset, value: upperBound, otherValue: (range ? lowerBound : null),
+        dragging: handle === 'upperBound' });
 
     let lower = null;
     if (range) {
       lower = cloneElement(customHandle, { className: lowerClassName,
         noTip: isNoTip, tipTransitionName: tipTransitionName, tipFormatter: tipFormatter,
-        vertical: vertical, offset: lowerOffset, value: lowerBound, dragging: handle === 'lowerBound' });
+        vertical: vertical, offset: lowerOffset, value: lowerBound, otherValue: upperBound,
+        dragging: handle === 'lowerBound' });
     }
 
     const sliderClassName = classNames({


### PR DESCRIPTION
This allows more flexibility when implementing a customHandle
by allowing you to use the position of the lowerbound while
calculating the offset of the upperbound, and vice versa.

Some example use cases: 
* Upper and lower bounds should always be X distance apart
* Upper/lower handle should stick to the range end when the other is less/greater than X
* One handle should change style based on the proximity of the other