### PR TITLE
Add 'style' node to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "licenses": "MIT",
   "main": "./lib/index.js",
+  "style": "./assets/index.css",
   "config": {
     "port": 8005
   },


### PR DESCRIPTION
Many modules in npm are starting to expose their css entry files in their `package.json` files. This allows tools like `postcss-import`, `parcelify`, `npm-css`, `rework-npm` and `npm-less` to import *rc-slider* straight from node_modules directory.

Example:
```css
@import 'rc-slider';
```

The same way as `main` node, but for css 😄 

Reference:
https://github.com/twbs/bootstrap/pull/12441