### PR TITLE
Add multi-range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ slider ui component for react
 
 <img src="https://t.alipayobjects.com/images/T1wO8fXd4rXXXXXXXX.png" width="550"/>
 
+<img src="http://i.giphy.com/l46Cs36c9HrHMExoc.gif"/>
+
 
 ## Feature
 
@@ -112,7 +114,13 @@ ReactDOM.render(<Rcslider />, container);
           <td>allowCross</td>
           <td>boolean</td>
           <td>true</td>
-          <td>When `range` is `true`, `allowCross` could be set as `true` to allow those two handles cross.</td>
+          <td>When `range` is `true`, `allowCross` could be set as `true` to allow those handles to cross.</td>
+        </tr>
+        <tr>
+          <td>pushable</td>
+          <td>boolean or number</td>
+          <td>true</td>
+          <td>When `range` is `true`, `pushable` could be set as `true` to allow pushing of surrounding handles when moving an handle. When set to a number, the number will be the minimum ensured distance between handles. Example: <img src="http://i.giphy.com/l46Cs36c9HrHMExoc.gif"/></td>
         </tr>
         <tr>
           <td>vertical</td>

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ ReactDOM.render(<Rcslider />, container);
         </tr>
         <tr>
           <td>range</td>
-          <td>boolean</td>
+          <td>boolean or number</td>
           <td>false</td>
-          <td>Determines the type of slider. If range is `true`, two handles will be rendered in order to select a range.</td>
+          <td>Determines the type of slider. If range is `true`, two handles will be rendered in order to select a range. If range is a number, multiple handles will be rendered (number + 1). Using `range={true}` is equivalent to `range={1}`.</td>
         </tr>
         <tr>
           <td>allowCross</td>
@@ -122,15 +122,15 @@ ReactDOM.render(<Rcslider />, container);
         </tr>
         <tr>
           <td>defaultValue</td>
-          <td>number or [number, number]</td>
+          <td>number or [number, number, ...]</td>
           <td>0 or [0, 0]</td>
-          <td>Set initial positions of handles. If range is `false`, the type of `defaultValue` should be `number`. Otherwise, `[number, number]`</td>
+          <td>Set initial positions of handles. If range is `false`, the type of `defaultValue` should be `number`. Otherwise, `[number, number, ...]`</td>
         </tr>
         <tr>
           <td>value</td>
-          <td>number or [number, number]</td>
+          <td>number or [number, number, ...]</td>
           <td></td>
-          <td>Set current positions of handles. If range is `false`, the type of `defaultValue` should be `number`. Otherwise, `[number, number]`</td>
+          <td>Set current positions of handles. If range is `false`, the type of `defaultValue` should be `number`. Otherwise, `[number, number, ...]`</td>
         </tr>
         <tr>
           <td>handle</td>

--- a/examples/range.js
+++ b/examples/range.js
@@ -106,6 +106,10 @@ ReactDOM.render(
       <Slider range value={[20, 40]} />
     </div>
     <div style={style}>
+      <p>Multi Range</p>
+      <Slider range={3} value={[20, 40, 60, 80]} />
+    </div>
+    <div style={style}>
       <p>Customized Range</p>
       <CustomizedRange />
     </div>

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -35,7 +35,7 @@ class Slider extends React.Component {
     const defaultValue = ('defaultValue' in props ? props.defaultValue : initialValue);
     const value = (props.value !== undefined ? props.value : defaultValue);
 
-    const bounds = range ? value : [min, value].map(v => this.trimAlignValue(v));
+    const bounds = (range ? value : [min, value]).map(v => this.trimAlignValue(v));
 
     let recent;
     if (range && bounds[0] === bounds[bounds.length - 1] && bounds[0] === max) {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -31,7 +31,7 @@ class Slider extends React.Component {
     super(props);
 
     const {range, min, max} = props;
-    const initialValue = range ? new Array(range + 1).fill(min) : min;
+    const initialValue = range ? new Array(range + 1).map(() => min) : min;
     const defaultValue = ('defaultValue' in props ? props.defaultValue : initialValue);
     const value = (props.value !== undefined ? props.value : defaultValue);
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -122,7 +122,7 @@ class Slider extends React.Component {
     nextBounds[state.handle] = value;
     let nextHandle = state.handle;
     if (props.allowCross) {
-      nextBounds.sort((a, b) => a > b);
+      nextBounds.sort((a, b) => a - b);
       nextHandle = nextBounds.indexOf(value);
     }
     this.onChange({

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -31,7 +31,7 @@ class Slider extends React.Component {
     super(props);
 
     const {range, min, max} = props;
-    const initialValue = range ? new Array(range + 1).map(() => min) : min;
+    const initialValue = range ? Array.apply(null, Array(range + 1)).map(() => min) : min;
     const defaultValue = ('defaultValue' in props ? props.defaultValue : initialValue);
     const value = (props.value !== undefined ? props.value : defaultValue);
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -356,6 +356,7 @@ class Slider extends React.Component {
       dragging: handle === i,
       key: i,
     }));
+    if (!range) { handles.shift(); }
 
     const isIncluded = included || range;
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -239,12 +239,14 @@ class Slider extends React.Component {
     if (val >= max) {
       val = max;
     }
-    if (!allowCross && handle > 0 && val <= bounds[handle - 1]) {
+    /* eslint-disable eqeqeq */
+    if (!allowCross && handle != null && handle > 0 && val <= bounds[handle - 1]) {
       val = bounds[handle - 1];
     }
-    if (!allowCross && handle < bounds.length - 1 && val >= bounds[handle + 1]) {
+    if (!allowCross && handle != null && handle < bounds.length - 1 && val >= bounds[handle + 1]) {
       val = bounds[handle + 1];
     }
+    /* eslint-enable eqeqeq */
 
     const points = Object.keys(marks).map(parseFloat);
     if (step !== null) {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -47,7 +47,7 @@ class Slider extends React.Component {
     this.state = {
       handle: null,
       recent: recent,
-      bounds
+      bounds,
     };
   }
 
@@ -361,12 +361,12 @@ class Slider extends React.Component {
 
     const tracks = [];
     for (let i = 1; i < bounds.length; ++i) {
-      const className = classNames({
+      const trackClassName = classNames({
         [`${prefixCls}-track`]: true,
         [`${prefixCls}-track-${i}`]: true,
       });
       tracks.push(
-          <Track className={className} vertical={vertical} included={isIncluded}
+          <Track className={trackClassName} vertical={vertical} included={isIncluded}
                  offset={offsets[i - 1]} length={offsets[i] - offsets[i - 1]} key={i} />
       );
     }
@@ -424,7 +424,7 @@ Slider.propTypes = {
   dots: React.PropTypes.bool,
   range: React.PropTypes.oneOfType([
     React.PropTypes.bool,
-    React.PropTypes.number
+    React.PropTypes.number,
   ]),
   vertical: React.PropTypes.bool,
   allowCross: React.PropTypes.bool,

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -24,7 +24,7 @@ describe('rc-slider', function test() {
 
   it('should render a Slider with default value correctly', () => {
     const sliderWithDefaultValue = ReactDOM.render(<Slider defaultValue={50} />, div);
-    expect(sliderWithDefaultValue.state.upperBound).to.be(50);
+    expect(sliderWithDefaultValue.state.bounds[1]).to.be(50);
     expect(ReactTestUtils
            .scryRenderedDOMComponentsWithClass(sliderWithDefaultValue, 'rc-slider-handle')[0]
            .style.cssText)
@@ -40,7 +40,7 @@ describe('rc-slider', function test() {
 
   it('should render a Slider with value corrently', () => {
     const sliderWithValue = ReactDOM.render(<Slider value={50} />, div);
-    expect(sliderWithValue.state.upperBound).to.be(50);
+    expect(sliderWithValue.state.bounds[1]).to.be(50);
     expect(ReactTestUtils
            .scryRenderedDOMComponentsWithClass(sliderWithValue, 'rc-slider-handle')[0]
            .style.cssText)
@@ -61,31 +61,92 @@ describe('rc-slider', function test() {
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track').length).to.be(1);
   });
 
+  it('should render a Multi-Range with correct DOM structure', () => {
+    const multiRange = ReactDOM.render(<Slider range={3} />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider').length).to.be(1);
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-handle').length).to.be(4);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-handle-1').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-handle-2').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-handle-3').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-handle-4').length).to.be(1);
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-track').length).to.be(3);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-track-1').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-track-2').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider-track-3').length).to.be(1);
+  });
+
   it('should render a Range with default value correctly', () => {
     const rangeWithDefaultValue = ReactDOM.render(<Slider range defaultValue={[0, 50]} />, div);
-    expect(rangeWithDefaultValue.state.lowerBound).to.be(0);
-    expect(rangeWithDefaultValue.state.upperBound).to.be(50);
+    expect(rangeWithDefaultValue.state.bounds[0]).to.be(0);
+    expect(rangeWithDefaultValue.state.bounds[1]).to.be(50);
     expect(ReactTestUtils
-           .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[0]
-           .style.cssText)
+      .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[0]
+      .style.cssText)
       .to.match(/left: 50%;/);
     expect(ReactTestUtils
-           .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[1]
-           .style.cssText)
+      .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[1]
+      .style.cssText)
       .to.match(/left: 0%;/);
 
     const trackStyle = ReactTestUtils
-            .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-track')[0]
-            .style.cssText;
+      .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-track')[0]
+      .style.cssText;
     expect(trackStyle).to.match(/left: 0%;/);
     expect(trackStyle).to.match(/width: 50%;/);
     expect(trackStyle).to.match(/visibility: visible;/);
   });
 
+  it('should render a Multi-Range with default value correctly', () => {
+    const multiRangeWithDefaultValue = ReactDOM.render(<Slider range={3} defaultValue={[0, 25, 50, 75]} />, div);
+    expect(multiRangeWithDefaultValue.state.bounds[0]).to.be(0);
+    expect(multiRangeWithDefaultValue.state.bounds[1]).to.be(25);
+    expect(multiRangeWithDefaultValue.state.bounds[2]).to.be(50);
+    expect(multiRangeWithDefaultValue.state.bounds[3]).to.be(75);
+    expect(ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[0]
+      .style.cssText)
+      .to.match(/left: 75%;/);
+    expect(ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[1]
+      .style.cssText)
+      .to.match(/left: 50%;/);
+    expect(ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[2]
+      .style.cssText)
+      .to.match(/left: 25%;/);
+    expect(ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[3]
+      .style.cssText)
+      .to.match(/left: 0%;/);
+
+    const track1Style = ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-track-1')[0]
+      .style.cssText;
+    expect(track1Style).to.match(/left: 0%;/);
+    expect(track1Style).to.match(/width: 25%;/);
+    expect(track1Style).to.match(/visibility: visible;/);
+
+    const track2Style = ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-track-2')[0]
+      .style.cssText;
+    expect(track2Style).to.match(/left: 25%;/);
+    expect(track2Style).to.match(/width: 25%;/);
+    expect(track2Style).to.match(/visibility: visible;/);
+
+    const track3Style = ReactTestUtils
+      .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-track-3')[0]
+      .style.cssText;
+    expect(track3Style).to.match(/left: 50%;/);
+    expect(track3Style).to.match(/width: 25%;/);
+    expect(track3Style).to.match(/visibility: visible;/);
+  });
+
   it('should render a Range with value correctly', () => {
     const rangeWithValue = ReactDOM.render(<Slider range value={[50, 100]} />, div);
-    expect(rangeWithValue.state.lowerBound).to.be(50);
-    expect(rangeWithValue.state.upperBound).to.be(100);
+    expect(rangeWithValue.state.bounds[0]).to.be(50);
+    expect(rangeWithValue.state.bounds[1]).to.be(100);
     expect(ReactTestUtils
            .scryRenderedDOMComponentsWithClass(rangeWithValue, 'rc-slider-handle')[0]
            .style.cssText)
@@ -128,16 +189,16 @@ describe('rc-slider', function test() {
 
   it('should not set value greater than `max` or smaller `min`', () => {
     const sliderWithMin = ReactDOM.render(<Slider value={0} min={10} />, div);
-    expect(sliderWithMin.state.upperBound).to.be(10);
+    expect(sliderWithMin.state.bounds[1]).to.be(10);
     ReactDOM.unmountComponentAtNode(div);
 
     const sliderWithMax = ReactDOM.render(<Slider value={100} max={90} />, div);
-    expect(sliderWithMax.state.upperBound).to.be(90);
+    expect(sliderWithMax.state.bounds[1]).to.be(90);
     ReactDOM.unmountComponentAtNode(div);
 
     const range = ReactDOM.render(<Slider range value={[0, 100]} min={10} max={90} />, div);
-    expect(range.state.lowerBound).to.be(10);
-    expect(range.state.upperBound).to.be(90);
+    expect(range.state.bounds[0]).to.be(10);
+    expect(range.state.bounds[1]).to.be(90);
     ReactDOM.unmountComponentAtNode(div);
   });
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -84,11 +84,11 @@ describe('rc-slider', function test() {
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[0]
       .style.cssText)
-      .to.match(/left: 50%;/);
+      .to.match(/left: 0%;/);
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-handle')[1]
       .style.cssText)
-      .to.match(/left: 0%;/);
+      .to.match(/left: 50%;/);
 
     const trackStyle = ReactTestUtils
       .scryRenderedDOMComponentsWithClass(rangeWithDefaultValue, 'rc-slider-track')[0]
@@ -107,19 +107,19 @@ describe('rc-slider', function test() {
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[0]
       .style.cssText)
-      .to.match(/left: 75%;/);
+      .to.match(/left: 0%;/);
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[1]
       .style.cssText)
-      .to.match(/left: 50%;/);
+      .to.match(/left: 25%;/);
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[2]
       .style.cssText)
-      .to.match(/left: 25%;/);
+      .to.match(/left: 50%;/);
     expect(ReactTestUtils
       .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-handle')[3]
       .style.cssText)
-      .to.match(/left: 0%;/);
+      .to.match(/left: 75%;/);
 
     const track1Style = ReactTestUtils
       .scryRenderedDOMComponentsWithClass(multiRangeWithDefaultValue, 'rc-slider-track-1')[0]
@@ -150,11 +150,11 @@ describe('rc-slider', function test() {
     expect(ReactTestUtils
            .scryRenderedDOMComponentsWithClass(rangeWithValue, 'rc-slider-handle')[0]
            .style.cssText)
-      .to.match(/left: 100%;/);
+      .to.match(/left: 50%;/);
     expect(ReactTestUtils
            .scryRenderedDOMComponentsWithClass(rangeWithValue, 'rc-slider-handle')[1]
            .style.cssText)
-      .to.match(/left: 50%;/);
+      .to.match(/left: 100%;/);
 
     const trackStyle = ReactTestUtils
             .scryRenderedDOMComponentsWithClass(rangeWithValue, 'rc-slider-track')[0]


### PR DESCRIPTION
Added support for more than 2 handles using `<Slider range={<number>} />`.
`number` is the number of tracks (i.e., `number === nHandles + 1`).

Example of `<Slider range={2} value={[25, 50, 65]} />`:

![multi-range](http://i67.tinypic.com/2v3fud1.jpg)
>CSS is different because of my application custom stylesheets...

### Pushable Handles
I also need pushable handles in my webapp...

The `pushable` property can be set to `true` to enable handle-pushing. When it is a number, the number represents the minimum distance between handles when pushing (`pushable={true}` is equivalent to `pushable={1}`).

Example of `<Slider range={3} pushable={10} defaultValue={[10, 25, 45, 70]} />`:

![pushable-handles](http://i.giphy.com/l46Cs36c9HrHMExoc.gif)

It also works correctly with any weird combination of `marks` and `step`.

### Implementation Details
- Instead of `lowerBound` and `upperBound`, the `Slider`'s state was changed to store a `bounds` array.
- Pushable handles calculates beforehand (and caches) all possible handle positions, taking into account `marks` and `step`. It then tries to push the surrounding handles away from the moving handle until the needed threshold (the value of `pushable`) is satisfied.

### IMPORTANT
I couldn't manage to run the test suite. I've cloned the original `slider` repository. Executed:
```
npm install
npm start
```
But when I go to *http://localhost:8005/examples/*, I'm missing resources (they are being searched in the wrong place...). It's the same for tests.

I've only run manual tests on my webapp.

I did modify the test suite, and also added some tests for the new multi-range, but someone must run the test suite to ensure everything works...