### PR TITLE
Fix issue where invalid bounds would be calculated

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -260,8 +260,9 @@ class Slider extends React.Component {
     if (val <= min) {
       val = min;
     }
-    if (val >= max) {
-      val = max;
+    const maxSelectableValue = (Math.floor((max - min) / step) * step) + min;
+    if (val >= maxSelectableValue) {
+      val = maxSelectableValue;
     }
     /* eslint-disable eqeqeq */
     if (!allowCross && handle != null && handle > 0 && val <= bounds[handle - 1]) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -210,7 +210,7 @@ describe('rc-slider', function test() {
   it('should set appropriate bounds when the range, max, and min aren\'t an exact multiple of the step', () => {
     const min = 0.5;
     const max = 2.1;
-    const slider = ReactDOM.render(<Slider max={max} min={min} value={[1,3]} range={true}/>, div);
+    const slider = ReactDOM.render(<Slider max={max} min={min} value={[0,3]} range={true}/>, div);
 
     slider.state.bounds.forEach((bound) => {
       expect(bound).to.be.greaterThan(min);

--- a/tests/index.js
+++ b/tests/index.js
@@ -206,4 +206,15 @@ describe('rc-slider', function test() {
     const slider = ReactDOM.render(<Slider vertical />, div);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-vertical').length).to.be(1);
   });
+  
+  it('should set appropriate bounds when the range, max, and min aren\'t an exact multiple of the step', () => {
+    const min = 0.5;
+    const max = 2.1;
+    const slider = ReactDOM.render(<Slider max={max} min={min} value={[1,3]} range={true}/>, div);
+
+    slider.state.bounds.forEach((bound) => {
+      expect(bound).to.be.greaterThan(min);
+      expect(bound).to.be.lessThan(max);
+    });
+  });
 });


### PR DESCRIPTION
In some cases, specifically when max and min aren't clean multiples of the step, the bounds can be set to invalid values (> max). The test case added in this PR fails on the current version.

This is a big problem because a controlled slider that encounters this bug will enter a near-infinite (this bug caused call stack overflow errors in our application) render loop as it continually receives, and passes down, new values that are still invalid.

The issue is that the call to Math.round [here](https://github.com/react-component/slider/blob/master/src/Slider.jsx#L277) can push the value above the max.
For example, if max is 2.1, min is 0.5, and step is 1, then the expression `(val - min) / step` is `(2.1 - 0.5) / 1 === 1.6`, which is then rounded up to 2 (and then the min is added, giving us a new value of 3, which is above the max).

 To resolve this, instead of using the given maximum as the upper limit, I've used the closest smaller value that could be selected (i.e. that is an integer multiple of step above the min). I believe this is the least disruptive means of resolving this bug.