### PR TITLE
Add `prefixTrack` property for range sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>Determines the type of slider. If range is `true`, two handles will be rendered in order to select a range. If range is a number, multiple handles will be rendered (number + 1). Using `range={true}` is equivalent to `range={1}`.</td>
         </tr>
         <tr>
+          <td>prefixTrack</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>When `range` is `true`, `prefixTrack` could be set as `true` to add an additional track from the slider's start to the first handle.</td>
+        </tr>
+        <tr>
           <td>allowCross</td>
           <td>boolean</td>
           <td>true</td>

--- a/examples/range.js
+++ b/examples/range.js
@@ -112,6 +112,10 @@ ReactDOM.render(
       <Slider range={3} defaultValue={[20, 40, 60, 80]} />
     </div>
     <div style={style}>
+      <p>Multi Range (`range=4`) with `pushable=10`</p>
+      <Slider range={3} defaultValue={[20, 40, 60, 80]} pushable={10} />
+    </div>
+    <div style={style}>
       <p>Customized Range</p>
       <CustomizedRange />
     </div>

--- a/examples/range.js
+++ b/examples/range.js
@@ -116,6 +116,10 @@ ReactDOM.render(
       <Slider range={3} defaultValue={[20, 40, 60, 80]} pushable={10} />
     </div>
     <div style={style}>
+      <p>Range with `prefixTrack=true`</p>
+      <Slider range defaultValue={[20, 40]} prefixTrack />
+    </div>
+    <div style={style}>
       <p>Customized Range</p>
       <CustomizedRange />
     </div>

--- a/examples/range.js
+++ b/examples/range.js
@@ -108,8 +108,8 @@ ReactDOM.render(
       <Slider range value={[20, 40]} />
     </div>
     <div style={style}>
-      <p>Multi Range</p>
-      <Slider range={3} value={[20, 40, 60, 80]} />
+      <p>Multi Range (`range=3`)</p>
+      <Slider range={3} defaultValue={[20, 40, 60, 80]} />
     </div>
     <div style={style}>
       <p>Customized Range</p>

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -405,6 +405,7 @@ class Slider extends React.Component {
         dots,
         included,
         range,
+        prefixTrack,
         step,
         marks,
         max, min,
@@ -458,6 +459,18 @@ class Slider extends React.Component {
         <Track className={trackClassName} vertical={vertical} included={isIncluded}
           offset={offsets[i - 1]} length={offsets[i] - offsets[i - 1]} key={i}
         />
+      );
+    }
+
+    if (range && prefixTrack) {
+      const trackClassName = classNames({
+        [`${prefixCls}-track`]: true,
+        [`${prefixCls}-track-0`]: true,
+        [`${prefixCls}-track-prefix`]: true,
+      });
+      tracks.unshift(
+          <Track className={trackClassName} vertical={vertical} included={isIncluded}
+                 offset={0} length={offsets[0]} key="prefix" />
       );
     }
 
@@ -518,6 +531,7 @@ Slider.propTypes = {
     React.PropTypes.bool,
     React.PropTypes.number,
   ]),
+  prefixTrack: React.PropTypes.bool,
   vertical: React.PropTypes.bool,
   allowCross: React.PropTypes.bool,
   pushable: React.PropTypes.oneOfType([
@@ -543,6 +557,7 @@ Slider.defaultProps = {
   disabled: false,
   dots: false,
   range: false,
+  prefixTrack: false,
   vertical: false,
   allowCross: true,
   pushable: false,

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -470,7 +470,8 @@ class Slider extends React.Component {
       });
       tracks.unshift(
           <Track className={trackClassName} vertical={vertical} included={isIncluded}
-                 offset={0} length={offsets[0]} key="prefix" />
+            offset={0} length={offsets[0]} key="prefix"
+          />
       );
     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -62,6 +62,17 @@ describe('rc-slider', function test() {
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track').length).to.be(1);
   });
 
+  it('should render a prefix track when `prefixTrack=true`', () => {
+    const range = ReactDOM.render(<Slider range prefixTrack />, div);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-handle').length).to.be(2);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track').length).to.be(2);
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track-prefix').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track-0').length).to.be(1);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(range, 'rc-slider-track-1').length).to.be(1);
+  });
+
   it('should render a Multi-Range with correct DOM structure', () => {
     const multiRange = ReactDOM.render(<Slider range={3} />, div);
     expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(multiRange, 'rc-slider').length).to.be(1);


### PR DESCRIPTION
Range sliders render a track between every two handles. I've added a `prefixTrack` property (defaulted to `false`) that enables adding a track from offset 0 to the first handle (with css classes `track track-0 track-prefix`).

Also in this pull request:
- Fixed multi-range example (to use `defaultValue` instead of `value`)
- Add `pushable` example
- Add `prefixTrack` example
