### PR TITLE
Colors for Tracks and Handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ ReactDOM.render(<Rcslider />, container);
         </tr>
         <tr>
           <td>marks</td>
-          <td>object{number: string} or object{number: object{ style, label }}</td>
+          <td>object{number: string} or object{number: object{ style, label, color }}</td>
           <td>{}</td>
-          <td>Mark on the slider. The key determines the position, and the value determines what will show. If you want to set the style of a specific mark point, the value should be an object which contains `style` and `label` properties.</td>
+          <td>Mark on the slider. The key determines the position, and the value determines what will show. If you want to set the style of a specific mark point, the value should be an object which contains `style`, `label` and `color`(optional) properties.</td>
         </tr>
         <tr>
           <td>step</td>

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -36,10 +36,10 @@ export default class Handle extends React.Component {
       color,
     } = this.props;
 
-    const style = Object.assign(
-      vertical ?
-        { bottom: `${offset}%` } :
-        { left: `${offset}%` }, color ? { borderColor: `${color}` } : { });
+    const style = vertical ? { bottom: `${offset}%` } : { left: `${offset}%` };
+    if (color) {
+      style.borderColor = `${color}`;
+    }
     const handle = (
       <div className={className} style={style}
         onMouseUp={this.showTooltip.bind(this)}

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -33,9 +33,13 @@ export default class Handle extends React.Component {
       value,
       dragging,
       noTip,
+      color,
     } = this.props;
 
-    const style = vertical ? { bottom: `${offset}%` } : { left: `${offset}%` };
+    const style = Object.assign(
+      vertical ?
+        { bottom: `${offset}%` } :
+        { left: `${offset}%` }, color ? { borderColor: `${color}` } : { });
     const handle = (
       <div className={className} style={style}
         onMouseUp={this.showTooltip.bind(this)}
@@ -74,4 +78,5 @@ Handle.propTypes = {
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,
   noTip: React.PropTypes.bool,
+  color: React.PropTypes.string,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -196,6 +196,14 @@ class Slider extends React.Component {
     this.onChange({ bounds: nextBounds });
   }
 
+  getMarkColor(index) {
+    const { marks } = this.props;
+    const markPoint = marks[index];
+    const markPointIsObject = typeof markPoint === 'object' &&
+            !React.isValidElement(markPoint);
+    return markPointIsObject ? markPoint.color : undefined;
+  }
+
   getValue() {
     const { bounds } = this.state;
     return this.props.range ? bounds : bounds[1];
@@ -443,6 +451,7 @@ class Slider extends React.Component {
       offset: offsets[i],
       dragging: handle === i,
       key: i,
+      color: this.getMarkColor(v),
     }));
     if (!range) { handles.shift(); }
 
@@ -454,9 +463,16 @@ class Slider extends React.Component {
         [`${prefixCls}-track`]: true,
         [`${prefixCls}-track-${i}`]: true,
       });
+
+      const gradient = [];
+      const lowerColor = this.getMarkColor(bounds[0]);
+      const upperColor = this.getMarkColor(bounds[1]);
+      if (lowerColor) gradient.push(lowerColor);
+      if (upperColor) gradient.push(upperColor);
+
       tracks.push(
         <Track className={trackClassName} vertical={vertical} included={isIncluded}
-          offset={offsets[i - 1]} length={offsets[i] - offsets[i - 1]} key={i}
+          offset={offsets[i - 1]} length={offsets[i] - offsets[i - 1]} key={i} gradient={gradient}
         />
       );
     }

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -1,16 +1,29 @@
 import React from 'react';
 
-const Track = ({ className, included, vertical, offset, length }) => {
+const Track = ({ className, included, vertical, offset, length, gradient }) => {
   const style = {
     visibility: included ? 'visible' : 'hidden',
   };
+  let gradientDirection = '';
   if (vertical) {
     style.bottom = `${offset}%`;
     style.height = `${length}%`;
+    gradientDirection = 'top';
   } else {
     style.left = `${offset}%`;
     style.width = `${length}%`;
+    gradientDirection = 'right';
   }
+
+  if (gradient.length > 0) {
+    const startColor = gradient[0];
+    const endColor = (gradient.length > 1) ? gradient[1] : gradient[0];
+    style.background = [
+      `linear-gradient(to ${gradientDirection}, ${startColor} , ${endColor})`,
+      `${endColor}`,
+    ];
+  }
+
   return <div className={className} style={style} />;
 };
 


### PR DESCRIPTION
I have done some changes on demand for my project. 
Just wondering if you are interested in merging it back.
Open to discusion / suggestions.

You can now define marks as
```
var marks = {
      0: { style: {}, label: 'Zero', color: '#fff' },
      1: { style: {}, label: 'One', color: '#234' },
      2: { style: {}, label: 'Two', color: 'red' },
      3: { style: {}, label: 'Three', color: 'black' },
      4: { style: {}, label: 'Four', color: '#783390' }
    };
```
If `color` is selected: 
- Handle will take `color` when positioned over the mark
- Track will be coloured with a linear gradient from `color` in mark one to `color` in mark 2.