### PR TITLE
Account for position difference between handle and event origin when dragging

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -1,3 +1,4 @@
+import { findDOMNode } from 'react-dom';
 import React, { cloneElement } from 'react';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import classNames from 'classnames';
@@ -20,6 +21,13 @@ function getTouchPosition(vertical, e) {
 
 function getMousePosition(vertical, e) {
   return vertical ? e.clientY : e.pageX;
+}
+
+function getHandleCenterPosition(vertical, handle) {
+  const coords = handle.getBoundingClientRect();
+  return vertical ?
+    coords.top + (coords.height * 0.5) :
+    coords.left + (coords.width * 0.5);
 }
 
 function pauseEvent(e) {
@@ -104,7 +112,7 @@ class Slider extends React.Component {
 
   onMouseMove(e) {
     const position = getMousePosition(this.props.vertical, e);
-    this.onMove(e, position);
+    this.onMove(e, position - this.dragOffset);
   }
 
   onTouchMove(e) {
@@ -114,7 +122,7 @@ class Slider extends React.Component {
     }
 
     const position = getTouchPosition(this.props.vertical, e);
-    this.onMove(e, position);
+    this.onMove(e, position - this.dragOffset);
   }
 
   onMove(e, position) {
@@ -149,7 +157,14 @@ class Slider extends React.Component {
   onTouchStart(e) {
     if (isNotTouchEvent(e)) return;
 
-    const position = getTouchPosition(this.props.vertical, e);
+    let position = getTouchPosition(this.props.vertical, e);
+    if (!this.isEventFromHandle(e)) {
+      this.dragOffset = 0;
+    } else {
+      const handlePosition = getHandleCenterPosition(this.props.vertical, e.target);
+      this.dragOffset = position - handlePosition;
+      position = handlePosition;
+    }
     this.onStart(position);
     this.addDocumentEvents('touch');
     pauseEvent(e);
@@ -157,7 +172,15 @@ class Slider extends React.Component {
 
   onMouseDown(e) {
     if (e.button !== 0) { return; }
-    const position = getMousePosition(this.props.vertical, e);
+
+    let position = getMousePosition(this.props.vertical, e);
+    if (!this.isEventFromHandle(e)) {
+      this.dragOffset = 0;
+    } else {
+      const handlePosition = getHandleCenterPosition(this.props.vertical, e.target);
+      this.dragOffset = position - handlePosition;
+      position = handlePosition;
+    }
     this.onStart(position);
     this.addDocumentEvents('mouse');
     pauseEvent(e);
@@ -257,6 +280,13 @@ class Slider extends React.Component {
       this._getPointsCache = { marks, step, points };
     }
     return this._getPointsCache.points;
+  }
+
+  isEventFromHandle(e) {
+    return this.state.bounds.some((x, i) => (
+        this.refs[`handle-${i}`] &&
+        e.target === findDOMNode(this.refs[`handle-${i}`])
+    ));
   }
 
   isValueOutOfBounds(value, props) {
@@ -457,6 +487,7 @@ class Slider extends React.Component {
       offset: offsets[i],
       dragging: handle === i,
       key: i,
+      ref: `handle-${i}`,
     }));
     if (!range) { handles.shift(); }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,18 @@ const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-addons-test-utils');
 const Slider = require('..');
 
+function createSliderWrapperComponent() {
+  return class SliderWrapper extends React.Component {
+    render() {
+      return (
+        <div style={{ position: `absolute`, width: `100px`, height: `10px` }}>
+          <Slider ref="slider"/>
+        </div>
+      );
+    }
+  };
+}
+
 require('../assets/index.less');
 
 describe('rc-slider', function test() {
@@ -231,5 +243,101 @@ describe('rc-slider', function test() {
     handle.dispatchEvent(up);
 
     expect(values.length).to.be(0);
+  });
+
+  it('should set `dragOffset` to correct value when the left handle is clicked off-center', () => {
+    const slider = ReactDOM.render(<Slider />, div);
+    const leftHandle = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-handle')[0];
+    slider.onMouseDown({
+      type: 'mousedown',
+      target: leftHandle,
+      pageX: 5, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(5);
+  });
+
+  it('should respect `dragOffset` while dragging the handle via MouseEvents', () => {
+    const SliderWrapper = createSliderWrapperComponent();
+    const slider = ReactDOM.render(<SliderWrapper/>, div).refs.slider;
+    const leftHandle = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-handle')[0];
+    slider.onMouseDown({
+      type: 'mousedown',
+      target: leftHandle,
+      pageX: 5, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(5);
+    slider.onMouseMove({
+      type: 'mousemove',
+      target: leftHandle,
+      pageX: 14, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.getValue()).to.be(9);
+  });
+
+  it('should set `dragOffset` to 0 when the MouseEvent target isn\'t a handle', () => {
+    const slider = ReactDOM.render(<Slider />, div);
+    const sliderTrack = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-track')[0];
+    slider.onMouseDown({
+      type: 'mousedown',
+      target: sliderTrack,
+      pageX: 5, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(0);
+  });
+
+  it('should set `dragOffset` to correct value when the left handle is touched off-center', () => {
+    const slider = ReactDOM.render(<Slider />, div);
+    const leftHandle = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-handle')[0];
+    slider.onTouchStart({
+      type: 'touchstart',
+      target: leftHandle,
+      touches: [{ pageX: 5 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(5);
+  });
+
+  it('should respect `dragOffset` while dragging the handle via TouchEvents', () => {
+    const SliderWrapper = createSliderWrapperComponent();
+    const slider = ReactDOM.render(<SliderWrapper/>, div).refs.slider;
+    const leftHandle = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-handle')[0];
+    slider.onTouchStart({
+      type: 'touchstart',
+      target: leftHandle,
+      touches: [{ pageX: 5 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(5);
+    slider.onTouchMove({
+      type: 'touchmove',
+      target: leftHandle,
+      touches: [{ pageX: 14 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.getValue()).to.be(9);
+  });
+
+  it('should set `dragOffset` to 0 when the TouchEvent target isn\'t a handle', () => {
+    const slider = ReactDOM.render(<Slider />, div);
+    const sliderTrack = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-track')[0];
+    slider.onTouchStart({
+      type: 'touchstart',
+      target: sliderTrack,
+      touches: [{ pageX: 5 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(slider.dragOffset).to.be(0);
   });
 });


### PR DESCRIPTION
When a user initially clicks on a handle, the slider positions the handle so the center is under the pointer. If the user doesn't click exactly in the center of the handle, this causes the handle to "jump" and changes the slider's value, which may not be what the user intended.

This PR updates the position logic to account for the difference between the initial handle position and the initial pointer position, so the handles are positioned relative to the delta between their origin and the pointer origin. This ensures the slider value doesn't change until the pointer moves.

Let me know if there's anything I should add to the PR. Thanks.