### PR TITLE
Add support for customizing a mark label in the :hover state

### DIFF
--- a/src/Marks.jsx
+++ b/src/Marks.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const Marks = ({ className, vertical, marks, included, upperBound, lowerBound, max, min }) => {
+const Marks = ({ className, vertical, marks, included, upperBound,
+                 lowerBound, max, min, marksHover }) => {
   const marksKeys = Object.keys(marks);
   const marksCount = marksKeys.length;
   const unit = 100 / (marksCount - 1);
@@ -14,6 +15,7 @@ const Marks = ({ className, vertical, marks, included, upperBound, lowerBound, m
     const markClassName = classNames({
       [`${className}-text`]: true,
       [`${className}-text-active`]: isActived,
+      [`${className}-text-hover`]: marksHover[point],
     });
 
     const bottomStyle = {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -66,6 +66,7 @@ class Slider extends React.Component {
 
     this.state = {
       handle: null,
+      marksHover: {},
       recent,
       bounds,
     };
@@ -282,6 +283,15 @@ class Slider extends React.Component {
     return this._getPointsCache.points;
   }
 
+  setMarkHover(point, value) {
+    this.setState({
+      marksHover: {
+        ...this.state.marksHover,
+        [point]: value,
+      },
+    });
+  }
+
   isEventFromHandle(e) {
     return this.state.bounds.some((x, i) => (
         this.refs[`handle-${i}`] &&
@@ -438,6 +448,7 @@ class Slider extends React.Component {
     const {
         handle,
         bounds,
+        marksHover,
     } = this.state;
     const {
         className,
@@ -522,11 +533,14 @@ class Slider extends React.Component {
         <Steps prefixCls={prefixCls} vertical = {vertical} marks={marks} dots={dots} step={step}
           included={isIncluded} lowerBound={bounds[0]}
           upperBound={bounds[bounds.length - 1]} max={max} min={min}
+          onMarkMouseOver={(point) => this.setMarkHover(point, true)}
+          onMarkMouseOut={(point) => this.setMarkHover(point, false)}
         />
         {handles}
         <Marks className={`${prefixCls}-mark`} vertical = {vertical} marks={marks}
           included={isIncluded} lowerBound={bounds[0]}
           upperBound={bounds[bounds.length - 1]} max={max} min={min}
+          marksHover={marksHover}
         />
         {children}
       </div>

--- a/src/Steps.jsx
+++ b/src/Steps.jsx
@@ -18,7 +18,8 @@ function calcPoints(vertical, marks, dots, step, min, max) {
 }
 
 const Steps = ({ prefixCls, vertical, marks, dots, step, included,
-                lowerBound, upperBound, max, min }) => {
+                lowerBound, upperBound, max, min, onMarkMouseOver,
+                onMarkMouseOut }) => {
   const range = max - min;
   const elements = calcPoints(vertical, marks, dots, step, min, max).map((point) => {
     const offset = `${Math.abs(point - min) / range * 100}%`;
@@ -30,8 +31,16 @@ const Steps = ({ prefixCls, vertical, marks, dots, step, included,
       [`${prefixCls}-dot`]: true,
       [`${prefixCls}-dot-active`]: isActived,
     });
-
-    return <span className={pointClassName} style={style} key={point} />;
+    const isMark = marks[point] !== undefined;
+    return (
+      <span
+        className={pointClassName}
+        onMouseOver={() => isMark && onMarkMouseOver(point)}
+        onMouseOut={() => isMark && onMarkMouseOut(point)}
+        style={style}
+        key={point}
+      />
+    );
   });
 
   return <div className={`${prefixCls}-step`}>{elements}</div>;

--- a/tests/index.js
+++ b/tests/index.js
@@ -340,4 +340,15 @@ describe('rc-slider', function test() {
     });
     expect(slider.dragOffset).to.be(0);
   });
+
+  it('should add rc-slider-mark-text-hover to a mark text when mouse is over the mark', () => {
+    const slider = ReactDOM.render(<Slider marks={{ 30: '30' }} />, div);
+    const dot = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-dot')[0];
+    const text = ReactTestUtils.scryRenderedDOMComponentsWithClass(slider, 'rc-slider-mark-text')[0];
+    expect(text.className).to.be('rc-slider-mark-text');
+    ReactTestUtils.Simulate.mouseOver(dot);
+    expect(text.className).to.be('rc-slider-mark-text rc-slider-mark-text-hover');
+    ReactTestUtils.Simulate.mouseOut(dot);
+    expect(text.className).to.be('rc-slider-mark-text');
+  });
 });


### PR DESCRIPTION
When the mouse pointer is over a dot on the slider, add `rc-slider-mark-text-hover` class to the corresponding label.
This can't be done with CSS as the dot and text tags are not related in the DOM.
This may be useful when you want marks to react somehow to mouse movements, e.g. show/hide labels
