### PR TITLE
Make the second argument to tipFormatter the index of the handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ ReactDOM.render(<Rcslider />, container);
           <td>tipFormatter</td>
           <td>function or `null`</td>
           <td></td>
-          <td>Format the value of the tooltip if it shows. If `null` the tooltip will always be hidden.</td>
+          <td>Format the value of the tooltip if it shows. If `null` the tooltip will always be hidden. When given a function, the first argument will be the value and the second will be the index of the slider handle.</td>
         </tr>
         <tr>
           <td>dots</td>

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -34,6 +34,7 @@ export default class Handle extends React.Component {
       value,
       dragging,
       noTip,
+      index,
     } = this.props;
 
     const style = vertical ? { bottom: `${offset}%` } : { left: `${offset}%` };
@@ -55,7 +56,7 @@ export default class Handle extends React.Component {
         prefixCls={tooltipPrefixCls || `${prefixCls}-tooltip`}
         placement="top"
         visible={isTooltipVisible}
-        overlay={<span>{tipFormatter(value)}</span>}
+        overlay={<span>{tipFormatter(value, index)}</span>}
         delay={0}
         transitionName={tipTransitionName}
       >
@@ -76,4 +77,5 @@ Handle.propTypes = {
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,
   noTip: React.PropTypes.bool,
+  index: React.PropTypes.number,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -486,6 +486,7 @@ class Slider extends React.Component {
       value: v,
       offset: offsets[i],
       dragging: handle === i,
+      index: i,
       key: i,
       ref: `handle-${i}`,
     }));


### PR DESCRIPTION
This is useful when working with an array of objects:

```jsx
const items = [{ name: 'A', value: 25 }, { name: 'B', value: 60 }];
const tipFormatter = (value, index) => items[index].name;

<Slider
  value={items.map(item => item.value)}
  tipFormatter={tipFormatter}
/>
```

By the way, I really wish that this package could be installed as a git source. I totally understand the desire to keep build files out of the repo, but not committing `lib` is very inconvenient. For me to use the fork I've created, I basically have to vendor the entire project.