### PR TITLE
fix slider start position

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -249,7 +249,7 @@ class Slider extends React.Component {
     const slider = this.refs.slider;
     const rect = slider.getBoundingClientRect();
 
-    return this.props.vertical ? rect.top : rect.left;
+    return this.props.vertical ? (window.scrollY + rect.top) : (window.scrollX + rect.left);
   }
 
   getPrecision(step) {


### PR DESCRIPTION
When magnifying screen, I cannot touch and move handles on the slider correctly.

and found it:
```es6
   getSliderStart() {
     const slider = this.refs.slider;
     const rect = slider.getBoundingClientRect();
 
     return this.props.vertical ? rect.top : rect.left;
```

and

```es6
   calcValueByPos(position) {
     const pixelOffset = position - this.getSliderStart();
```

https://developer.mozilla.org/en/docs/Web/API/Element/getBoundingClientRect
> This means that the rectangle's boundary edges (top, left, bottom, and right) change their values every time the scrolling position changes (because their values are relative to the viewport and not absolute). If you need the bounding rectangle relative to the top-left corner of the document, just add the current scrolling position to the top and left properties (these can be obtained using window.scrollX and window.scrollY) to get a bounding rectangle which is independent from the current scrolling position.

position is absolute value, so it is probably required to compensate for original values.