### PR TITLE
prop to show toolTip always

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# rc-slider
+# rc-slider-custom
 ---
 
-slider ui component for react
+slider ui component for react with option to show toolTip always
 
 [![NPM version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
@@ -47,7 +47,7 @@ slider ui component for react
 
 ## install
 
-[![rc-slider](https://nodei.co/npm/rc-slider.png)](https://npmjs.org/package/rc-slider)
+[![rc-slider](https://nodei.co/npm/rc-slider.png)](https://npmjs.org/package/rc-slider-custom)
 
 ## Usage
 
@@ -56,7 +56,7 @@ require('rc-slider/assets/index.css');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var Rcslider = require('rc-slider');
+var Rcslider = require('rc-slider-custom');
 ReactDOM.render(<Rcslider />, container);
 ```
 
@@ -220,4 +220,4 @@ http://localhost:8005/node_modules/rc-server/node_modules/node-jscover/lib/front
 
 ## License
 
-rc-slider is released under the MIT license.
+rc-slider-custom is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>NOOP</td>
           <td>`onAfterChange` will be triggered when `ontouchend` or `onmouseup` is triggered.</td>
         </tr>
+        <tr>
+          <td>toolTipVisibleAlways</td>
+          <td>bool</td>
+          <td>false</td>
+          <td>If `toolTipVisibleAlways` is set to true, the tooltip will be visible always.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -84,6 +84,10 @@ ReactDOM.render(
       <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} />
     </div>
     <div style={style}>
+      <p>Basic Slider with ToolTip visible always</p>
+      <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} toolTipVisibleAlways={true} />
+    </div>
+    <div style={style}>
       <p>Basic Slider，`step=20`</p>
       <Slider step={20} defaultValue={50} onBeforeChange={log} />
     </div>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -85,8 +85,7 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Basic Slider with ToolTip visible always</p>
-      <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} toolTipVisibleAlways
-      />
+      <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} toolTipVisibleAlways/>
     </div>
     <div style={style}>
       <p>Basic Slider，`step=20`</p>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -85,7 +85,8 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Basic Slider with ToolTip visible always</p>
-      <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} toolTipVisibleAlways={true} />
+      <Slider tipTransitionName="rc-slider-tooltip-zoom-down" onChange={log} toolTipVisibleAlways
+      />
     </div>
     <div style={style}>
       <p>Basic Slider，`step=20`</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-slider",
-  "version": "5.3.4",
+  "name": "rc-slider-custom",
+  "version": "1.0.0",
   "description": "slider ui component for react",
   "keywords": [
     "react",
@@ -8,8 +8,8 @@
     "react-slider",
     "slider"
   ],
-  "homepage": "http://github.com/react-component/slider",
-  "author": "sima.zhang1990@gmail.com",
+  "homepage": "https://github.com/Gunavel/slider.git",
+  "author": "sgb.rated@gmail.com",
   "repository": {
     "type": "git",
     "url": "git@github.com:react-component/slider.git"

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -54,7 +54,6 @@ export default class Handle extends React.Component {
       <Tooltip
         prefixCls={tooltipPrefixCls || `${prefixCls}-tooltip`}
         placement="top"
-        visible={isTooltipVisible}
         overlay={<span>{tipFormatter(value)}</span>}
         delay={0}
         transitionName={tipTransitionName}

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -34,6 +34,7 @@ export default class Handle extends React.Component {
       value,
       dragging,
       noTip,
+      toolTipVisibleAlways,
     } = this.props;
 
     const style = vertical ? { bottom: `${offset}%` } : { left: `${offset}%` };
@@ -50,10 +51,14 @@ export default class Handle extends React.Component {
     }
 
     const isTooltipVisible = dragging || this.state.isTooltipVisible;
+
+    const toolTipVisibilityOverride = toolTipVisibleAlways ? true : isTooltipVisible;
+
     return (
       <Tooltip
         prefixCls={tooltipPrefixCls || `${prefixCls}-tooltip`}
         placement="top"
+        visible={toolTipVisibilityOverride}
         overlay={<span>{tipFormatter(value)}</span>}
         delay={0}
         transitionName={tipTransitionName}
@@ -75,4 +80,5 @@ Handle.propTypes = {
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,
   noTip: React.PropTypes.bool,
+  toolTipVisibleAlways: React.PropTypes.bool,
 };

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -454,6 +454,7 @@ class Slider extends React.Component {
         tipTransitionName,
         tipFormatter,
         children,
+        toolTipVisibleAlways,
     } = this.props;
 
     const customHandle = this.props.handle;
@@ -488,6 +489,7 @@ class Slider extends React.Component {
       dragging: handle === i,
       key: i,
       ref: `handle-${i}`,
+      toolTipVisibleAlways,
     }));
     if (!range) { handles.shift(); }
 
@@ -571,6 +573,7 @@ Slider.propTypes = {
     React.PropTypes.bool,
     React.PropTypes.number,
   ]),
+  toolTipVisibleAlways: React.PropTypes.bool,
 };
 
 Slider.defaultProps = {
@@ -593,6 +596,7 @@ Slider.defaultProps = {
   vertical: false,
   allowCross: true,
   pushable: false,
+  toolTipVisibleAlways: false,
 };
 
 export default Slider;


### PR DESCRIPTION
'toolTipVisibleAlways' props is added for showing the ToolTip always. If this prop is not added, showing the toolTip falls back to mouse events.