### PR TITLE
Allow to align the tooltip with the slider. Also allow to set the html container for the tooltip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>Align the tooltip with the slider.</td>
         </tr>
         <tr>
+          <td>tipContainer</td>
+          <td>function</td>
+          <td></td>
+          <td>Function returning html node which will act as tooltip container</td>
+        </tr>
+        <tr>
           <td>dots</td>
           <td>bool</td>
           <td>false</td>

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ ReactDOM.render(<Rcslider />, container);
           <td>Format the value of the tooltip if it shows. If `null` the tooltip will always be hidden.</td>
         </tr>
         <tr>
+          <td>tipAlign</td>
+          <td>Object: alignConfig of [dom-align](https://github.com/yiminghe/dom-align)</td>
+          <td></td>
+          <td>Align the tooltip with the slider.</td>
+        </tr>
+        <tr>
           <td>dots</td>
           <td>bool</td>
           <td>false</td>

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -29,6 +29,7 @@ export default class Handle extends React.Component {
       className,
       tipTransitionName,
       tipAlign,
+      tipContainer,
       tipFormatter,
       vertical,
       offset,
@@ -60,6 +61,7 @@ export default class Handle extends React.Component {
         delay={0}
         transitionName={tipTransitionName}
         align={tipAlign}
+        getTooltipContainer={tipContainer}
       >
         {handle}
       </Tooltip>
@@ -75,6 +77,7 @@ Handle.propTypes = {
   offset: React.PropTypes.number,
   tipTransitionName: React.PropTypes.string,
   tipAlign: React.PropTypes.object,
+  tipContainer: React.PropTypes.func,
   tipFormatter: React.PropTypes.func,
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -28,6 +28,7 @@ export default class Handle extends React.Component {
       tooltipPrefixCls,
       className,
       tipTransitionName,
+      tipAlign,
       tipFormatter,
       vertical,
       offset,
@@ -58,6 +59,7 @@ export default class Handle extends React.Component {
         overlay={<span>{tipFormatter(value)}</span>}
         delay={0}
         transitionName={tipTransitionName}
+        align={tipAlign}
       >
         {handle}
       </Tooltip>
@@ -72,6 +74,7 @@ Handle.propTypes = {
   vertical: React.PropTypes.bool,
   offset: React.PropTypes.number,
   tipTransitionName: React.PropTypes.string,
+  tipAlign: React.PropTypes.object,
   tipFormatter: React.PropTypes.func,
   value: React.PropTypes.number,
   dragging: React.PropTypes.bool,

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -453,6 +453,7 @@ class Slider extends React.Component {
         max, min,
         tipTransitionName,
         tipAlign,
+        tipContainer,
         tipFormatter,
         children,
     } = this.props;
@@ -478,6 +479,7 @@ class Slider extends React.Component {
       noTip: isNoTip,
       tipTransitionName,
       tipAlign,
+      tipContainer,
       tipFormatter,
       vertical,
     };
@@ -563,6 +565,7 @@ Slider.propTypes = {
   handle: React.PropTypes.element,
   tipTransitionName: React.PropTypes.string,
   tipAlign: React.PropTypes.object,
+  tipContainer: React.PropTypes.func,
   tipFormatter: React.PropTypes.func,
   dots: React.PropTypes.bool,
   range: React.PropTypes.oneOfType([

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -452,6 +452,7 @@ class Slider extends React.Component {
         marks,
         max, min,
         tipTransitionName,
+        tipAlign,
         tipFormatter,
         children,
     } = this.props;
@@ -476,6 +477,7 @@ class Slider extends React.Component {
       tooltipPrefixCls,
       noTip: isNoTip,
       tipTransitionName,
+      tipAlign,
       tipFormatter,
       vertical,
     };
@@ -560,6 +562,7 @@ Slider.propTypes = {
   onAfterChange: React.PropTypes.func,
   handle: React.PropTypes.element,
   tipTransitionName: React.PropTypes.string,
+  tipAlign: React.PropTypes.object,
   tipFormatter: React.PropTypes.func,
   dots: React.PropTypes.bool,
   range: React.PropTypes.oneOfType([
@@ -578,6 +581,7 @@ Slider.defaultProps = {
   prefixCls: 'rc-slider',
   className: '',
   tipTransitionName: '',
+  tipAlign: {},
   min: 0,
   max: 100,
   step: 1,


### PR DESCRIPTION
This allows to align the tooltip with the slider. It takes advantage of the `align` prop of the [rc-tooltip](https://github.com/react-component/tooltip) dependency.

Also I found the case where it would be useful to set the html container for the tooltip. I came across the problem when tooltip doesn't display correctly relating to the slider element. It occurred when the container of the slider is scrollable and doesn't match the tooltip container. When scrolling, slider element moves whereas tooltip stays in the same place. The issue arises because the `rc-tooltip` appends tooltip to the `body` by default. The ability to allow to set the container for the tooltip will solve the issue. 