### PR TITLE
Update Usage section to use accurate component name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ require('rc-slider/assets/index.css');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var Rcslider = require('rc-slider');
-ReactDOM.render(<Rcslider />, container);
+var Slider = require('rc-slider');
+ReactDOM.render(<Slider />, container);
 ```
 
 ## API


### PR DESCRIPTION
I was getting errors on my unit tests when trying to import the <Rcslider /> component. Turns out the correct name of the component is Slider. I felt the Usage section of the Readme was a bit misleading.