### PR TITLE
Fix slider value calculation

### DIFF
--- a/src/createSlider.jsx
+++ b/src/createSlider.jsx
@@ -154,7 +154,7 @@ export default function createSlider(Component) {
 
     calcValue(offset) {
       const { vertical, min, max } = this.props;
-      const ratio = Math.abs(offset / this.getSliderLength());
+      const ratio = Math.abs(Math.max(offset, 0) / this.getSliderLength());
       const value = vertical ? (1 - ratio) * (max - min) + min : ratio * (max - min) + min;
       return value;
     }

--- a/tests/common.test.js
+++ b/tests/common.test.js
@@ -121,6 +121,28 @@ describe('createSlider', () => {
     expect(wrapper.node.getValue()).toBe(9);
   });
 
+  it('should not go to right direction when mouse go to the left', () => {
+    const wrapper = mount(<Slider />);
+    wrapper.node.sliderRef.clientWidth = 100; // jsdom doesn't provide clientWidth
+    const leftHandle = wrapper.find('.rc-slider-handle').get(0);
+    wrapper.simulate('mousedown', {
+      type: 'mousedown',
+      target: leftHandle,
+      pageX: 5, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(wrapper.node.getValue()).toBe(0); // zero on start
+    wrapper.node.onMouseMove({ // to propagation
+      type: 'mousemove',
+      target: leftHandle,
+      pageX: 0, button: 0,
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(wrapper.node.getValue()).toBe(0); // still zero
+  });
+
   it('should set `dragOffset` to 0 when the MouseEvent target isn\'t a handle', () => {
     const wrapper = mount(<Slider />);
     wrapper.node.sliderRef.clientWidth = 100; // jsdom doesn't provide clientWidth


### PR DESCRIPTION
How to reproduce:
1. Start dragging of slider
2. Move mouse to the left of the slider (or above the slider in a case of the vertical slider).
3. You will see that the slider value will be bigger than min value (and it starts moving in the right direction).

I guess it is unexpected behaviour.