### PR TITLE
fix: ensure ref is present before using

### DIFF
--- a/src/createSlider.jsx
+++ b/src/createSlider.jsx
@@ -66,6 +66,11 @@ export default function createSlider(Component) {
       }
     }
 
+    componentWillUnmount() {
+      if (super.componentWillUnmount) super.componentWillUnmount();
+      this.removeDocumentEvents();
+    }
+
     onMouseDown = (e) => {
       if (e.button !== 0) { return; }
 

--- a/src/createSlider.jsx
+++ b/src/createSlider.jsx
@@ -65,6 +65,7 @@ export default function createSlider(Component) {
         );
       }
     }
+
     onMouseDown = (e) => {
       if (e.button !== 0) { return; }
 
@@ -121,12 +122,16 @@ export default function createSlider(Component) {
     }
 
     onMouseMove = (e) => {
+      if (!this.sliderRef) {
+        this.onEnd();
+        return;
+      }
       const position = utils.getMousePosition(this.props.vertical, e);
       this.onMove(e, position - this.dragOffset);
     }
 
     onTouchMove = (e) => {
-      if (utils.isNotTouchEvent(e)) {
+      if (utils.isNotTouchEvent(e) || !this.sliderRef) {
         this.onEnd();
         return;
       }

--- a/tests/common.test.js
+++ b/tests/common.test.js
@@ -206,4 +206,21 @@ describe('createSlider', () => {
     });
     expect(wrapper.node.dragOffset).toBe(0);
   });
+
+  it('Should remove event listeners if unmounted during drag', () => {
+    const wrapper = mount(<Slider />);
+    wrapper.node.sliderRef.clientWidth = 100; // jsdom doesn't provide clientWidth
+    const sliderTrack = wrapper.find('.rc-slider-track').get(0);
+    wrapper.simulate('touchstart', {
+      type: 'touchstart',
+      target: sliderTrack,
+      touches: [{ pageX: 5 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    expect(wrapper.getNode().onTouchUpListener).toBeTruthy();
+    wrapper.getNode().onTouchUpListener.remove = jest.fn();
+    wrapper.unmount();
+    expect(wrapper.getNode().onTouchUpListener.remove).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
It's possible for the ref to be undefined, especially when using async batching strategies.

For example:

```
TypeError: Cannot read property 'getBoundingClientRect' of null
  at getSliderStart(node_modules/rc-slider/lib/createSlider.js:170:0)
  at calcValueByPos(node_modules/rc-slider/lib/createSlider.js:196:0)
  at onMove(node_modules/rc-slider/lib/Slider.js:111:0)
  at callback(node_modules/rc-slider/lib/createSlider.js:120:0)
  at batchedUpdates(ui/utils/ReactRAFBatchingStrategy.js:29:13)
  at unstable_batchedUpdates(node_modules/react-dom/lib/ReactUpdates.js:97:0)
  at call(node_modules/rc-util/lib/Dom/addEventListener.js:21:0)
  at apply(node_modules/add-dom-event-listener/lib/index.js:17:0)
  at apply(node_modules/raven-js/src/raven.js:278:0)
```