### PR TITLE
fix: noticket - Re-add tipFormatter to Slider API

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -109,6 +109,7 @@ class Slider extends React.Component {
       vertical,
       included,
       disabled,
+      tipFormatter,
       handle: handleGenerator,
     } = this.props;
     const { value, dragging } = this.state;
@@ -120,6 +121,7 @@ class Slider extends React.Component {
       value,
       dragging,
       disabled,
+      tipFormatter,
       ref: h => this.saveHandle(0, h),
     });
     const track = (

--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -16,11 +16,11 @@ export default function createSliderWithTooltip(Component) {
         },
       });
     }
-    handleWithTooltip = ({ value, dragging, index, disabled, ...restProps }) => {
+    handleWithTooltip = ({ value, dragging, index, disabled, tipFormatter, ...restProps }) => {
       return (
         <Tooltip
           prefixCls="rc-slider-tooltip"
-          overlay={value}
+          overlay={tipFormatter && tipFormatter(value) || value}
           visible={!disabled && (this.state.visibles[index] || dragging)}
           onVisibleChange={visible => this.handleTooltipVisibleChange(index, visible)}
           placement="top"


### PR DESCRIPTION
## Summary

Would like to add the `tipFormatter` prop back to the `Slider` API, as in the [`Slider` API of old (v5.4.3)](https://github.com/react-component/slider/blob/f7aacbfe0a568878630b8a18eadc035fcf9c2937/src/Slider.jsx#L458). Is this the best way?

For example, if I want to format a number with a comma for every thousand:

```
const SliderWithTooltip = ReactSlider.createSliderWithTooltip(ReactSlider);

<SliderWithTooltip tipFormatter={tipFormatter} ... />
```

![image](https://cloud.githubusercontent.com/assets/6425166/23563224/a9182520-003d-11e7-98d2-384ef6fd3f4c.png)
