### PR TITLE
Add handleStyle and minimumTrackStyle props to Range

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -282,6 +282,8 @@ class Range extends React.Component {
       vertical,
       included,
       disabled,
+      minimumTrackStyle,
+      handleStyle,
       handle: handleGenerator,
     } = this.props;
 
@@ -299,6 +301,7 @@ class Range extends React.Component {
       dragging: handle === i,
       index: i,
       disabled,
+      handleStyle,
       ref: h => this.saveHandle(i, h),
     }));
 
@@ -315,6 +318,7 @@ class Range extends React.Component {
           included={included}
           offset={offsets[i - 1]}
           length={offsets[i] - offsets[i - 1]}
+          minimumTrackStyle={minimumTrackStyle}
           key={i}
         />
       );

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -18,6 +18,14 @@ class Range extends React.Component {
     ]),
     allowCross: PropTypes.bool,
     disabled: PropTypes.bool,
+    rangeTrackStyle: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.object,
+    ]),
+    rangeHandleStyle: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.object,
+    ]),
   };
 
   static defaultProps = {
@@ -282,8 +290,8 @@ class Range extends React.Component {
       vertical,
       included,
       disabled,
-      minimumTrackStyle,
-      handleStyle,
+      rangeTrackStyle,
+      rangeHandleStyle,
       handle: handleGenerator,
     } = this.props;
 
@@ -301,7 +309,7 @@ class Range extends React.Component {
       dragging: handle === i,
       index: i,
       disabled,
-      handleStyle,
+      handleStyle: rangeHandleStyle[i] || rangeHandleStyle,
       ref: h => this.saveHandle(i, h),
     }));
 
@@ -311,6 +319,7 @@ class Range extends React.Component {
         [`${prefixCls}-track`]: true,
         [`${prefixCls}-track-${i}`]: true,
       });
+
       return (
         <Track
           className={trackClassName}
@@ -318,7 +327,7 @@ class Range extends React.Component {
           included={included}
           offset={offsets[i - 1]}
           length={offsets[i] - offsets[i - 1]}
-          minimumTrackStyle={minimumTrackStyle}
+          minimumTrackStyle={rangeTrackStyle[i - 1] || rangeTrackStyle}
           key={i}
         />
       );


### PR DESCRIPTION
Previously the `handleStyle` and `minimumTrackStyle` props only worked with Slider. Added them to Range as well.

Maybe they could be renamed to `innerTrackStyle` and `outerTrackStyle`. It makes sense for Range, and for the slider I don't think it's too much of a stretch to consider the track to the left of the handle to be "inner".