### PR TITLE
Fix issue with multiple tooltips showing

### DIFF
--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -16,11 +16,13 @@ export default function createSliderWithTooltip(Component) {
       this.state = { visibles: {} };
     }
     handleTooltipVisibleChange = (index, visible) => {
-      this.setState({
-        visibles: {
-          ...this.state.visibles,
-          [index]: visible,
-        },
+      this.setState((prevState) => {
+        return {
+          visibles: {
+            ...prevState.visibles,
+            [index]: visible,
+          },
+        };
       });
     }
     handleWithTooltip = ({ value, dragging, index, disabled, ...restProps }) => {


### PR DESCRIPTION
This fixes an issue with `createSliderWithTooltip()` where multiple tooltips will be shown at once if the mouse is dragged over two or more handles quickly.

Reproduced here:
http://codepen.io/anon/pen/jmEPxV?editors=0011

This was due to the fact that multiple setStates would fire back to back and the second would apply old state values. Passing a function to setState (atomic update) was the fix.