### PR TITLE
Fix handle’s active style

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -59,11 +59,9 @@
     &:hover {
       border-color: tint(@primary-color, 20%);
     }
-    &-active {
-      &:active {
-        border-color: tint(@primary-color, 20%);
-        box-shadow: 0 0 5px tint(@primary-color, 20%);
-      }
+    &:active {
+      border-color: tint(@primary-color, 20%);
+      box-shadow: 0 0 5px tint(@primary-color, 20%);
     }
   }
 
@@ -126,6 +124,7 @@
 
     .@{prefixClass}-handle, .@{prefixClass}-dot {
       border-color: @disabledColor;
+      box-shadow: none;
       background-color: #fff;
       cursor: not-allowed;
     }


### PR DESCRIPTION
`.rc-slider-handle-active` was removed in [9ebe2de](https://github.com/react-component/slider/commit/9ebe2de0cbf13647dc2f49cf4ae45e5ff8b07eba#diff-4dfae13f53a5af8d1382d6a704e2ec40L384) which is why the active style wasn’t working. Instead of programmatically adding an active class, I simply use the `:active` pseudo-class now.