### PR TITLE
Fix #279 - Use getBoundingClientRect for proper scaled width of slider

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -170,7 +170,7 @@ export default function createSlider(Component) {
       }
 
       return this.props.vertical ?
-        slider.clientHeight : slider.clientWidth;
+        slider.getBoundingClientRect().height : slider.getBoundingClientRect().width;
     }
 
     calcValue(offset) {


### PR DESCRIPTION
Jcqt-390's solution also worked for me:
https://github.com/react-component/slider/issues/279