### PR TITLE
Bugfix/keep pushable

### DIFF
--- a/examples/range.js
+++ b/examples/range.js
@@ -117,6 +117,8 @@ class ControlledRangeDisableAcross extends React.Component {
     super(props);
     this.state = {
       value: [20, 40, 60, 80],
+      enablePushable: true,
+      pushable: 5,
     };
   }
   handleChange = (value) => {
@@ -124,14 +126,45 @@ class ControlledRangeDisableAcross extends React.Component {
       value,
     });
   }
+  enablePushable = e => {
+    this.setState({
+      enablePushable: e.target.checked,
+    });
+  }
+  changePushable = e => {
+    this.setState({
+      pushable: e.target.value || 0,
+    });
+  }
   render() {
     return (
-      <Range
-        value={this.state.value}
-        onChange={this.handleChange}
-        allowCross={false}
-        {...this.props}
-      />
+      <div>
+        <label htmlFor="enpushable">enable pushable:</label>
+        <input
+          type="checkbox"
+          name="enpushable"
+          onChange={this.enablePushable}
+          checked={this.state.enablePushable}
+        />
+        <br />
+        <label htmlFor="pushable">pushable:</label>
+        <input
+          type="number"
+          name="pushable"
+          onChange={this.changePushable}
+          value={this.state.pushable}
+          disabled={!this.state.enablePushable}
+        />
+        <br />
+        <br />
+        <Range
+          value={this.state.value}
+          onChange={this.handleChange}
+          allowCross={false}
+          pushable={this.state.enablePushable && this.state.pushable}
+          {...this.props}
+        />
+      </div>
     );
   }
 }
@@ -180,12 +213,8 @@ ReactDOM.render(
       <ControlledRange />
     </div>
     <div style={style}>
-      <p>Controlled Range, not allow across</p>
+      <p>Controlled Range, not allow across, with pushable</p>
       <ControlledRangeDisableAcross />
-    </div>
-    <div style={style}>
-      <p>Controlled Range, not allow across, pushable</p>
-      <ControlledRangeDisableAcross pushable/>
     </div>
     <div style={style}>
       <p>Multi Range</p>

--- a/examples/range.js
+++ b/examples/range.js
@@ -48,12 +48,7 @@ class CustomizedRange extends React.Component {
         <br />
         <button onClick={this.handleApply}>Apply</button>
         <br /><br />
-        <Range
-          allowCross={false}
-          pushable={10}
-          value={this.state.value}
-          onChange={this.onSliderChange}
-        />
+        <Range allowCross={false} value={this.state.value} onChange={this.onSliderChange} />
       </div>
     );
   }
@@ -161,11 +156,11 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Multi Range</p>
-      <Range count={3} defaultValue={[20, 40, 60, 80]} />
+      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable />
     </div>
     <div style={style}>
       <p>Multi Range with custom track and handle style</p>
-      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable={10}
+      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable
         trackStyle={[{ backgroundColor: 'red' }, { backgroundColor: 'green' }]}
         handleStyle={[{ backgroundColor: 'yellow' }, { backgroundColor: 'gray' }]}
         railStyle={{ backgroundColor: 'black' }}

--- a/examples/range.js
+++ b/examples/range.js
@@ -4,6 +4,8 @@ import 'rc-slider/assets/index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Slider from 'rc-slider';
+import PropTypes from 'prop-types';
+
 const Range = Slider.Range;
 
 const style = { width: 400, margin: 50 };
@@ -93,6 +95,9 @@ class DynamicBounds extends React.Component {
 }
 
 class ControlledRange extends React.Component {
+  static propTypes = {
+    allowCross: PropTypes.bool,
+  }
   constructor(props) {
     super(props);
     this.state = {
@@ -105,8 +110,9 @@ class ControlledRange extends React.Component {
     });
   }
   render() {
+    const { allowCross = true } = this.props;
     return (
-      <Range value={this.state.value} onChange={this.handleChange}/>
+      <Range value={this.state.value} onChange={this.handleChange} allowCross={allowCross}/>
     );
   }
 }
@@ -153,6 +159,10 @@ ReactDOM.render(
     <div style={style}>
       <p>Controlled Range</p>
       <ControlledRange />
+    </div>
+    <div style={style}>
+      <p>Controlled Range with not allowCross</p>
+      <ControlledRange allowCross={false} />
     </div>
     <div style={style}>
       <p>Multi Range</p>

--- a/examples/range.js
+++ b/examples/range.js
@@ -117,8 +117,6 @@ class ControlledRangeDisableAcross extends React.Component {
     super(props);
     this.state = {
       value: [20, 40, 60, 80],
-      enablePushable: true,
-      pushable: 5,
     };
   }
   handleChange = (value) => {
@@ -126,45 +124,14 @@ class ControlledRangeDisableAcross extends React.Component {
       value,
     });
   }
-  enablePushable = e => {
-    this.setState({
-      enablePushable: e.target.checked,
-    });
-  }
-  changePushable = e => {
-    this.setState({
-      pushable: e.target.value || 0,
-    });
-  }
   render() {
     return (
-      <div>
-        <label htmlFor="enpushable">enable pushable:</label>
-        <input
-          type="checkbox"
-          name="enpushable"
-          onChange={this.enablePushable}
-          checked={this.state.enablePushable}
-        />
-        <br />
-        <label htmlFor="pushable">pushable:</label>
-        <input
-          type="number"
-          name="pushable"
-          onChange={this.changePushable}
-          value={this.state.pushable}
-          disabled={!this.state.enablePushable}
-        />
-        <br />
-        <br />
-        <Range
-          value={this.state.value}
-          onChange={this.handleChange}
-          allowCross={false}
-          pushable={this.state.enablePushable && this.state.pushable}
-          {...this.props}
-        />
-      </div>
+      <Range
+        value={this.state.value}
+        onChange={this.handleChange}
+        allowCross={false}
+        {...this.props}
+      />
     );
   }
 }
@@ -213,8 +180,12 @@ ReactDOM.render(
       <ControlledRange />
     </div>
     <div style={style}>
-      <p>Controlled Range, not allow across, with pushable</p>
+      <p>Controlled Range, not allow across</p>
       <ControlledRangeDisableAcross />
+    </div>
+    <div style={style}>
+      <p>Controlled Range, not allow across, pushable=5</p>
+      <ControlledRangeDisableAcross pushable={5} />
     </div>
     <div style={style}>
       <p>Multi Range</p>

--- a/examples/range.js
+++ b/examples/range.js
@@ -48,7 +48,12 @@ class CustomizedRange extends React.Component {
         <br />
         <button onClick={this.handleApply}>Apply</button>
         <br /><br />
-        <Range allowCross={false} value={this.state.value} onChange={this.onSliderChange} />
+        <Range
+          allowCross={false}
+          pushable={10}
+          value={this.state.value}
+          onChange={this.onSliderChange}
+        />
       </div>
     );
   }
@@ -156,11 +161,11 @@ ReactDOM.render(
     </div>
     <div style={style}>
       <p>Multi Range</p>
-      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable />
+      <Range count={3} defaultValue={[20, 40, 60, 80]} />
     </div>
     <div style={style}>
       <p>Multi Range with custom track and handle style</p>
-      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable
+      <Range count={3} defaultValue={[20, 40, 60, 80]} pushable={10}
         trackStyle={[{ backgroundColor: 'red' }, { backgroundColor: 'green' }]}
         handleStyle={[{ backgroundColor: 'yellow' }, { backgroundColor: 'gray' }]}
         railStyle={{ backgroundColor: 'black' }}

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -269,17 +269,16 @@ class Range extends React.Component {
 
   ensureValueNotConflict(i, val, { allowCross, pushable: thershold }) {
     const state = this.state || {};
-    const { handle, bounds } = state;
+    const { bounds } = state;
+    const handle = (i === undefined) ? state.handle : i;
     thershold = Number(thershold);
     /* eslint-disable eqeqeq */
-    if (!allowCross && handle != null) {
-      if (i === undefined || i === handle) {
-        if (handle > 0 && val <= (bounds[handle - 1] + thershold)) {
-          return bounds[handle - 1] + thershold;
-        }
-        if (handle < bounds.length - 1 && val >= (bounds[handle + 1] - thershold)) {
-          return bounds[handle + 1] - thershold;
-        }
+    if (!allowCross && handle != null && bounds !== undefined) {
+      if (handle > 0 && val <= (bounds[handle - 1] + thershold)) {
+        return bounds[handle - 1] + thershold;
+      }
+      if (handle < bounds.length - 1 && val >= (bounds[handle + 1] - thershold)) {
+        return bounds[handle + 1] - thershold;
       }
     }
     /* eslint-enable eqeqeq */

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -261,17 +261,16 @@ class Range extends React.Component {
     return true;
   }
 
-  trimAlignValue(v, i, nextProps = {}) {
+  trimAlignValue(v, handle = this.state.handle, nextProps = {}) {
     const mergedProps = { ...this.props, ...nextProps };
     const valInRange = utils.ensureValueInRange(v, mergedProps);
-    const valNotConflict = this.ensureValueNotConflict(i, valInRange, mergedProps);
+    const valNotConflict = this.ensureValueNotConflict(handle, valInRange, mergedProps);
     return utils.ensureValuePrecision(valNotConflict, mergedProps);
   }
 
-  ensureValueNotConflict(i, val, { allowCross, pushable: thershold }) {
+  ensureValueNotConflict(handle, val, { allowCross, pushable: thershold }) {
     const state = this.state || {};
     const { bounds } = state;
-    const handle = (i === undefined) ? state.handle : i;
     thershold = Number(thershold);
     /* eslint-disable eqeqeq */
     if (!allowCross && handle != null && bounds !== undefined) {

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -263,7 +263,7 @@ class Range extends React.Component {
     return true;
   }
 
-  trimAlignValue(v, handle = this.state.handle, nextProps = {}) {
+  trimAlignValue(v, handle, nextProps = {}) {
     const mergedProps = { ...this.props, ...nextProps };
     const valInRange = utils.ensureValueInRange(v, mergedProps);
     const valNotConflict = this.ensureValueNotConflict(handle, valInRange, mergedProps);
@@ -273,6 +273,7 @@ class Range extends React.Component {
   ensureValueNotConflict(handle, val, { allowCross, pushable: thershold }) {
     const state = this.state || {};
     const { bounds } = state;
+    handle = handle === undefined ? state.handle : handle;
     thershold = Number(thershold);
     /* eslint-disable eqeqeq */
     if (!allowCross && handle != null && bounds !== undefined) {

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -162,10 +162,6 @@ export default function createSlider(Component) {
       /* eslint-enable no-unused-expressions */
     }
 
-    onMouseUp = () => {
-      this.removeDocumentEvents();
-    }
-
     onMouseMove = (e) => {
       if (!this.sliderRef) {
         this.onEnd();
@@ -268,7 +264,6 @@ export default function createSlider(Component) {
           className={sliderClassName}
           onTouchStart={disabled ? noop : this.onTouchStart}
           onMouseDown={disabled ? noop : this.onMouseDown}
-          onMouseUp={disabled ? noop : this.onMouseUp}
           onKeyDown={disabled ? noop : this.onKeyDown}
           onFocus={disabled ? noop : this.onFocus}
           onBlur={disabled ? noop : this.onBlur}

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -91,4 +91,30 @@ describe('Range', () => {
     wrapper.find('.rc-slider-handle').at(1).simulate('mouseLeave');
     expect(wrapper.state().visibles[1]).toBe(false);
   });
+
+  it('should keep pushable when not allowCross and setState', () => {
+    class CustomizedRange extends React.Component { // eslint-disable-line
+      constructor(props) {
+        super(props);
+        this.state = {
+          value: [20, 40],
+        };
+      }
+      getSlider() {
+        return this.refs.slider;
+      }
+      render() {
+        return <Range ref="slider" allowCross={false} value={this.state.value} pushable={10} />;
+      }
+    }
+    const wrapper = mount(<CustomizedRange />);
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(20);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+    wrapper.setState({ value: [30, 40] });
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+    wrapper.setState({ value: [35, 40] });
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+  });
 });

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -116,5 +116,34 @@ describe('Range', () => {
     wrapper.setState({ value: [35, 40] });
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+    wrapper.setState({ value: [30, 30] });
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+  });
+
+  it('should keep pushable with pushable s defalutValue when not allowCross and setState', () => {
+    class CustomizedRange extends React.Component { // eslint-disable-line
+      constructor(props) {
+        super(props);
+        this.state = {
+          value: [20, 40],
+        };
+      }
+      getSlider() {
+        return this.refs.slider;
+      }
+      render() {
+        return <Range ref="slider" allowCross={false} value={this.state.value} pushable />;
+      }
+    }
+    const wrapper = mount(<CustomizedRange />);
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(20);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+    wrapper.setState({ value: [40, 40] });
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(39);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
+    wrapper.setState({ value: [39, 38] });
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(39);
+    expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
   });
 });

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -155,7 +155,7 @@ describe('Range', () => {
 
     const mockRect = (wrapper) => {
       wrapper.instance().getSlider().sliderRef.getBoundingClientRect = () => ({
-        left: 10,
+        left: 0,
         width: 100,
       });
     };
@@ -169,16 +169,16 @@ describe('Range', () => {
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(20);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
 
-    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 10, pageY: 0 });
-    map.mousemove({ type: 'mousemove', pageX: 40, pageY: 0 });
-    map.mouseup({ type: 'mouseup', pageX: 40, pageY: 0 });
+    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 0, pageY: 0 });
+    map.mousemove({ type: 'mousemove', pageX: 30, pageY: 0 });
+    map.mouseup({ type: 'mouseup', pageX: 30, pageY: 0 });
 
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
 
-    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 10, pageY: 0 });
-    map.mousemove({ type: 'mousemove', pageX: 60, pageY: 0 });
-    map.mouseup({ type: 'mouseup', pageX: 60, pageY: 0 });
+    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 0, pageY: 0 });
+    map.mousemove({ type: 'mousemove', pageX: 50, pageY: 0 });
+    map.mouseup({ type: 'mouseup', pageX: 50, pageY: 0 });
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(39);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
   });

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -128,21 +128,51 @@ describe('Range', () => {
         this.state = {
           value: [20, 40],
         };
+        this.onChange = this.onChange.bind(this);
+      }
+      onChange(value) {
+        this.setState({
+          value,
+        });
       }
       getSlider() {
         return this.refs.slider;
       }
       render() {
-        return <Range ref="slider" allowCross={false} value={this.state.value} pushable />;
+        return <Range ref="slider" allowCross={false} value={this.state.value} pushable onChange={this.onChange} />;
       }
     }
-    const wrapper = mount(<CustomizedRange />);
+    const map = {};
+    document.addEventListener = jest.genMockFn().mockImplementation((event, cb) => {
+      map[event] = cb;
+    });
+
+    const mockRect = (wrapper) => {
+      wrapper.instance().getSlider().sliderRef.getBoundingClientRect = () => ({
+        left: 10,
+        width: 100,
+      });
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const wrapper = mount(<CustomizedRange />, { attachTo: container });
+    mockRect(wrapper);
+
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(20);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
-    wrapper.setState({ value: [40, 40] });
-    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(39);
+
+    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 10, pageY: 0 });
+    map.mousemove({ type: 'mousemove', pageX: 40, pageY: 0 });
+    map.mouseup({ type: 'mouseup', pageX: 40, pageY: 0 });
+
+    expect(wrapper.instance().getSlider().state.bounds[0]).toBe(30);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
-    wrapper.setState({ value: [39, 38] });
+
+    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 10, pageY: 0 });
+    map.mousemove({ type: 'mousemove', pageX: 60, pageY: 0 });
+    map.mouseup({ type: 'mouseup', pageX: 60, pageY: 0 });
     expect(wrapper.instance().getSlider().state.bounds[0]).toBe(39);
     expect(wrapper.instance().getSlider().state.bounds[1]).toBe(40);
   });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,4 @@
-global.requestAnimationFrame = global.requestAnimationFrame || function (cb) {
+global.requestAnimationFrame = global.requestAnimationFrame || function raf(cb) {
   return setTimeout(cb, 0);
 };
 


### PR DESCRIPTION
trace: #159 
when check the values in `componentWillReceiveProps`  function, you use `map` but no index or Corresponding handle. The handle will be always what you are move.  
Then it invoke `ensureValueNotConflict ` function, but `ensureValueNotConflict ` just return prev or next handle value. (I think it should in consideration of `thershold`)

So the gap of pushable not work when [`allowCross=false`](https://github.com/react-component/slider/issues/159#issuecomment-263282912) and [set the value props (to update the display at each state)](https://github.com/react-component/slider/issues/159#issue-181678834)

I just do it. but maybe someone has more elegant code. Many places invoke `trimAlignValue ` func, so it may not `index` and `nextProps` args sometimes. 

base issue #159  , after fixed, I make some examples： 
all examples I set `pushable={10}` and `allowCross={false}`

![pushable](https://user-images.githubusercontent.com/6723674/29153527-985a3d58-7dc0-11e7-8457-03ed77122cfc.gif)

![pushable2](https://user-images.githubusercontent.com/6723674/29153545-a5406506-7dc0-11e7-9f19-e0b76d277ec2.gif)

