### PR TITLE
Upgrade rc-tooltip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-runtime": "6.x",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.4",
-    "rc-tooltip": "^3.4.2",
+    "rc-tooltip": "^3.4.9",
     "rc-util": "^4.0.4",
     "shallowequal": "^1.0.1",
     "warning": "^3.0.0"


### PR DESCRIPTION
The rc-tooltip -> rc-trigger -> rc-align dependency is causing React 16 upgrade warnings. As far as I can tell, all of the libraries have been updated and we just need to upgrade rc-tooltip.

There might be some issues with rc-trigger and its portal implementation

#323 