### PR TITLE
change event binding to slider ownerDocument

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -138,13 +138,13 @@ export default function createSlider(Component) {
 
     addDocumentTouchEvents() {
       // just work for Chrome iOS Safari and Android Browser
-      this.onTouchMoveListener = addEventListener(document, 'touchmove', this.onTouchMove);
-      this.onTouchUpListener = addEventListener(document, 'touchend', this.onEnd);
+      this.onTouchMoveListener = addEventListener(this.sliderRef.ownerDocument, 'touchmove', this.onTouchMove);
+      this.onTouchUpListener = addEventListener(this.sliderRef.ownerDocument, 'touchend', this.onEnd);
     }
 
     addDocumentMouseEvents() {
-      this.onMouseMoveListener = addEventListener(document, 'mousemove', this.onMouseMove);
-      this.onMouseUpListener = addEventListener(document, 'mouseup', this.onEnd);
+      this.onMouseMoveListener = addEventListener(this.sliderRef.ownerDocument, 'mousemove', this.onMouseMove);
+      this.onMouseUpListener = addEventListener(this.sliderRef.ownerDocument, 'mouseup', this.onEnd);
     }
 
     removeDocumentEvents() {

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -86,6 +86,10 @@ export default function createSlider(Component) {
       this.removeDocumentEvents();
     }
 
+    componentDidMount() {
+      this.document = this.sliderRef.ownerDocument;
+    }
+
     onMouseDown = (e) => {
       if (e.button !== 0) { return; }
 
@@ -138,13 +142,13 @@ export default function createSlider(Component) {
 
     addDocumentTouchEvents() {
       // just work for Chrome iOS Safari and Android Browser
-      this.onTouchMoveListener = addEventListener(this.sliderRef.ownerDocument, 'touchmove', this.onTouchMove);
-      this.onTouchUpListener = addEventListener(this.sliderRef.ownerDocument, 'touchend', this.onEnd);
+      this.onTouchMoveListener = addEventListener(this.document, 'touchmove', this.onTouchMove);
+      this.onTouchUpListener = addEventListener(this.document, 'touchend', this.onEnd);
     }
 
     addDocumentMouseEvents() {
-      this.onMouseMoveListener = addEventListener(this.sliderRef.ownerDocument, 'mousemove', this.onMouseMove);
-      this.onMouseUpListener = addEventListener(this.sliderRef.ownerDocument, 'mouseup', this.onEnd);
+      this.onMouseMoveListener = addEventListener(this.document, 'mousemove', this.onMouseMove);
+      this.onMouseUpListener = addEventListener(this.document, 'mouseup', this.onEnd);
     }
 
     removeDocumentEvents() {


### PR DESCRIPTION
I noticed a problem that events binding to document. It has problem in frames that has they own document. It is better to use _el.ownerDocument_ to add all slider event listeners.