### PR TITLE
Add `inverted` prop to `Slider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following APIs are shared by Slider and Range.
 | vertical | boolean | `false` | If vertical is `true`, the slider will be vertical. |
 | handle | (props) => React.ReactNode | | A handle generator which could be used to customized handle. |
 | included | boolean | `true` | If the value is `true`, it means a continuous value interval, otherwise, it is a independent value. |
+| inverted | boolean | `false` | If the value is `true`, it means that the slider will be render from right to left instead of left to right |
 | disabled | boolean | `false` | If `true`, handles can't be moved. |
 | dots | boolean | `false` | When the `step` value is greater than 1, you can set the `dots` to  `true` if you want to render the slider with dots. |
 | onBeforeChange | Function | NOOP | `onBeforeChange` will be triggered when `ontouchstart` or `onmousedown` is triggered. |

--- a/examples/range.js
+++ b/examples/range.js
@@ -147,6 +147,18 @@ ReactDOM.render(
       <Range dots step={20} defaultValue={[20, 40]} onAfterChange={log} />
     </div>
     <div style={style}>
+      <p>Inverted Basic Range，`allowCross=false`</p>
+      <Range inverted allowCross={false} defaultValue={[0, 20]} onChange={log} />
+    </div>
+    <div style={style}>
+      <p>Inverted Basic Range，`step=20` </p>
+      <Range inverted step={20} defaultValue={[20, 20]} onBeforeChange={log} />
+    </div>
+    <div style={style}>
+      <p>Inverted Basic Range，`step=20, dots` </p>
+      <Range inverted dots step={20} defaultValue={[20, 40]} onAfterChange={log} />
+    </div>
+    <div style={style}>
       <p>Basic Range，disabled</p>
       <Range allowCross={false} defaultValue={[0, 20]} onChange={log} disabled />
     </div>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -100,6 +100,22 @@ ReactDOM.render(
       <Slider dots step={20} defaultValue={100} onAfterChange={log} dotStyle={{ borderColor: 'orange' }} activeDotStyle={{ borderColor: 'yellow' }} />
     </div>
     <div style={style}>
+      <p>Inverted Basic Slider</p>
+      <Slider inverted onChange={log} />
+    </div>
+    <div style={style}>
+      <p>Inverted Basic Slider，`step=20`</p>
+      <Slider inverted step={20} defaultValue={50} onBeforeChange={log} />
+    </div>
+    <div style={style}>
+      <p>Inverted Basic Slider，`step=20, dots`</p>
+      <Slider dots inverted step={20} defaultValue={100} onAfterChange={log} />
+    </div>
+    <div style={style}>
+      <p>Inverted Basic Slider，`step=20, dots, dotStyle={"{borderColor: 'orange'}"}, activeDotStyle={"{borderColor: 'yellow'}"}`</p>
+      <Slider dots inverted step={20} defaultValue={100} onAfterChange={log} dotStyle={{ borderColor: 'orange' }} activeDotStyle={{ borderColor: 'yellow' }} />
+    </div>
+    <div style={style}>
       <p>Slider with tooltip, with custom `tipFormatter`</p>
       <SliderWithTooltip
         tipFormatter={percentFormatter}

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -86,7 +86,7 @@ class Range extends React.Component {
     const bounds = this.getValue();
     props.onBeforeChange(bounds);
 
-    const value = this.calcValueByPos(position);
+    const value = this.calcValueByPos(position, props.inverted);
     this.startValue = value;
     this.startPosition = position;
 
@@ -117,7 +117,7 @@ class Range extends React.Component {
     const props = this.props;
     const state = this.state;
 
-    const value = this.calcValueByPos(position);
+    const value = this.calcValueByPos(position, props.inverted);
     const oldValue = state.bounds[state.handle];
     if (value === oldValue) return;
 
@@ -173,12 +173,12 @@ class Range extends React.Component {
   }
 
   getLowerBound() {
-    return this.state.bounds[0];
+    return this.props.inverted ? this.props.max - this.state.bounds[0] : this.state.bounds[0];
   }
 
   getUpperBound() {
     const { bounds } = this.state;
-    return bounds[bounds.length - 1];
+    return this.props.inverted ? this.state.bounds[0] : bounds[bounds.length - 1];
   }
 
   /**
@@ -332,8 +332,8 @@ class Range extends React.Component {
           className={trackClassName}
           vertical={vertical}
           included={included}
-          offset={offsets[i - 1]}
-          length={offsets[i] - offsets[i - 1]}
+          offset={this.props.inverted ? offsets[i] : offsets[i - 1]}
+          length={this.props.inverted ? offsets[i - 1] - offsets[i] : offsets[i] - offsets[i - 1]}
           style={trackStyle[index]}
           key={i}
         />

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -113,11 +113,11 @@ class Slider extends React.Component {
   }
 
   getLowerBound() {
-    return this.props.min;
+    return this.props.inverted ? this.state.value : this.props.min;
   }
 
   getUpperBound() {
-    return this.state.value;
+    return this.props.inverted ? this.props.max : this.state.value;
   }
 
   trimAlignValue(v, nextProps = {}) {
@@ -144,7 +144,7 @@ class Slider extends React.Component {
     const handle = handleGenerator({
       className: `${prefixCls}-handle`,
       vertical,
-      offset,
+      offset: this.props.inverted ? 100 - offset : offset,
       value,
       dragging,
       disabled,
@@ -160,7 +160,7 @@ class Slider extends React.Component {
         className={`${prefixCls}-track`}
         vertical={vertical}
         included={included}
-        offset={0}
+        offset={this.props.inverted ? 100 - offset : 0}
         length={offset}
         style={{
           ...minimumTrackStyle,

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -20,6 +20,7 @@ export default function createSlider(Component) {
       step: PropTypes.number,
       marks: PropTypes.object,
       included: PropTypes.bool,
+      inverted: PropTypes.bool,
       className: PropTypes.string,
       prefixCls: PropTypes.string,
       disabled: PropTypes.bool,
@@ -56,6 +57,7 @@ export default function createSlider(Component) {
       onChange: noop,
       onAfterChange: noop,
       included: true,
+      inverted: false,
       disabled: false,
       dots: false,
       vertical: false,
@@ -199,22 +201,22 @@ export default function createSlider(Component) {
       return this.props.vertical ? coords.height : coords.width;
     }
 
-    calcValue(offset) {
+    calcValue(offset, range) {
       const { vertical, min, max } = this.props;
       const ratio = Math.abs(Math.max(offset, 0) / this.getSliderLength());
       const value = vertical ? (1 - ratio) * (max - min) + min : ratio * (max - min) + min;
-      return value;
+      return range ? max - value : value;
     }
 
-    calcValueByPos(position) {
+    calcValueByPos(position, range = false) {
       const pixelOffset = position - this.getSliderStart();
-      const nextValue = this.trimAlignValue(this.calcValue(pixelOffset));
+      const nextValue = this.trimAlignValue(this.calcValue(pixelOffset, range));
       return nextValue;
     }
 
     calcOffset(value) {
-      const { min, max } = this.props;
-      const ratio = (value - min) / (max - min);
+      const { min, max, inverted } = this.props;
+      const ratio = inverted ? (max - value) / (max - min) : (value - min) / (max - min);
       return ratio * 100;
     }
 

--- a/tests/common/createSlider.test.js
+++ b/tests/common/createSlider.test.js
@@ -40,6 +40,16 @@ describe('createSlider', () => {
     expect(rangeWrapper.find('.rc-slider-dot-active').length).toBe(4);
   });
 
+  it('should render inverted when `inverted=true`', () => {
+    const sliderWrapper = mount(<Slider inverted value={40} step={10} />);
+    expect(sliderWrapper.find('.rc-slider-track').first().prop('offset')).toBe(40);
+    expect(sliderWrapper.find('.rc-slider-track').first().prop('length')).toBe(60);
+
+    const rangeWrapper = mount(<Range value={[20, 50]} step={10} dots />);
+    expect(rangeWrapper.find('.rc-slider-track').first().prop('offset')).toBe(20);
+    expect(rangeWrapper.find('.rc-slider-track').first().prop('length')).toBe(30);
+  });
+
   it('should not set value greater than `max` or smaller `min`', () => {
     const sliderWithMinWrapper = mount(<Slider value={0} min={10} />);
     expect(sliderWithMinWrapper.state('value')).toBe(10);


### PR DESCRIPTION
If `inverted` is passed to the Slider component, the slider is render
"reversed" with the track going right to left instead of left to right.

fixes #216