### PR TITLE
Increasing minimum version of rc-tooltip dependency that is compliant with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-runtime": "6.x",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.4",
-    "rc-tooltip": "^3.4.2",
+    "rc-tooltip": "^3.4.3",
     "rc-util": "^4.0.4",
     "shallowequal": "^1.0.1",
     "warning": "^3.0.0"


### PR DESCRIPTION
Addresses https://github.com/react-component/slider/issues/333#issuecomment-337313098