### PR TITLE
Do not render empty mark labels

### DIFF
--- a/src/common/Marks.jsx
+++ b/src/common/Marks.jsx
@@ -17,6 +17,14 @@ const Marks = ({
 
   const range = max - min;
   const elements = marksKeys.map(parseFloat).sort((a, b) => a - b).map(point => {
+    const markPoint = marks[point];
+    const markPointIsObject = typeof markPoint === 'object' &&
+            !React.isValidElement(markPoint);
+    const markLabel = markPointIsObject ? markPoint.label : markPoint;
+    if (!markLabel) {
+      return null;
+    }
+
     const isActive = (!included && point === upperBound) ||
             (included && point <= upperBound && point >= lowerBound);
     const markClassName = classNames({
@@ -36,11 +44,6 @@ const Marks = ({
     };
 
     const style = vertical ? bottomStyle : leftStyle;
-
-    const markPoint = marks[point];
-    const markPointIsObject = typeof markPoint === 'object' &&
-            !React.isValidElement(markPoint);
-    const markLabel = markPointIsObject ? markPoint.label : markPoint;
     const markStyle = markPointIsObject ?
             { ...style, ...markPoint.style } : style;
     return (

--- a/tests/common/marks.test.js
+++ b/tests/common/marks.test.js
@@ -6,7 +6,7 @@ const { Range } = Slider;
 
 describe('marks', () => {
   it('should render marks correctly when `marks` is not an empty object', () => {
-    const marks = { 0: '0', 30: '30', 100: '100' };
+    const marks = { 0: '0', 30: '30', 99: '', 100: '100' };
 
     const sliderWrapper = mount(<Slider value={30} marks={marks} />);
     expect(sliderWrapper.find('.rc-slider-mark-text').length).toBe(3);


### PR DESCRIPTION
Use-case: I have a slider bar for percent values. I use marks for
every allowed value (e.g. values from 2 to 5 are not allowed).
Displaying every mark label would flood the UI. So there are mark labels
displayed only for every 10th step, which also works fine without this
change (using: {10: '10%', 11: ''}).
This change just optimizes that there are no empty DOM nodes rendered.