### PR TITLE
Remove redundant css

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -115,12 +115,6 @@
     cursor: pointer;
     border-radius: 50%;
     vertical-align: middle;
-    &:first-child {
-      margin-left: -4px;
-    }
-    &:last-child {
-      margin-left: -4px;
-    }
     &-active {
       border-color: tint(@primary-color, 50%);
     }


### PR DESCRIPTION
Settings margin-left to the exact same value for :first-child, :last-child and the regular `.rc-slider-dot` seems redundant, and doesn't do anything.