### PR TITLE
Remove visibility property from rc-slider-track

### DIFF
--- a/src/common/Track.jsx
+++ b/src/common/Track.jsx
@@ -13,11 +13,10 @@ const Track = (props) => {
   };
 
   const elStyle = {
-    visibility: included ? 'visible' : 'hidden',
     ...style,
     ...positonStyle,
   };
-  return <div className={className} style={elStyle} />;
+  return included ? <div className={className} style={elStyle} /> : null;
 };
 
 export default Track;


### PR DESCRIPTION
Had an issue when range component placed inside dropdown which controlled by visibility property. And in result when dropdown is hidden rc-slider-track still visible.