### PR TITLE
fix snapshot testing with storyshots, enzyme, react-test-renderer

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -87,7 +87,8 @@ export default function createSlider(Component) {
     }
 
     componentDidMount() {
-      this.document = this.sliderRef.ownerDocument;
+      // Snapshot testing cannot handle refs, so be sure to null-check this.
+      this.document = this.sliderRef && this.sliderRef.ownerDocument;
     }
 
     onMouseDown = (e) => {


### PR DESCRIPTION
Fixes #338 

Since onTouchStart() et al are not called in snapshot testing, it is easy to avoid the crash.