### PR TITLE
Added forceVisible parameter to tipProps.

### DIFF
--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -40,6 +40,7 @@ export default function createSliderWithTooltip(Component) {
         prefixCls = 'rc-slider-tooltip',
         overlay = tipFormatter(value),
         placement = 'top',
+	    forceVisible = forceVisible || false,
         ...restTooltipProps,
       } = tipProps;
 
@@ -49,9 +50,10 @@ export default function createSliderWithTooltip(Component) {
           prefixCls={prefixCls}
           overlay={overlay}
           placement={placement}
-          visible={!disabled && (this.state.visibles[index] || dragging)}
+          visible={(!disabled && (this.state.visibles[index] || dragging)) || forceVisible}
           key={index}
         >
+
           <Handle
             {...restProps}
             style={{

--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -40,7 +40,7 @@ export default function createSliderWithTooltip(Component) {
         prefixCls = 'rc-slider-tooltip',
         overlay = tipFormatter(value),
         placement = 'top',
-	    forceVisible = forceVisible || false,
+        forceVisible = forceVisible || false,
         ...restTooltipProps,
       } = tipProps;
 

--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -40,7 +40,7 @@ export default function createSliderWithTooltip(Component) {
         prefixCls = 'rc-slider-tooltip',
         overlay = tipFormatter(value),
         placement = 'top',
-        forceVisible = forceVisible || false,
+        visible = visible || false,
         ...restTooltipProps,
       } = tipProps;
 
@@ -50,7 +50,7 @@ export default function createSliderWithTooltip(Component) {
           prefixCls={prefixCls}
           overlay={overlay}
           placement={placement}
-          visible={(!disabled && (this.state.visibles[index] || dragging)) || forceVisible}
+          visible={(!disabled && (this.state.visibles[index] || dragging)) || visible}
           key={index}
         >
 


### PR DESCRIPTION
If need always to show toolTip value.

I want to show toolTip always. But I can't change this state. It works only on hover. 
https://github.com/react-component/slider/blob/master/src/createSliderWithTooltip.jsx#L61
I added this changes because custom toolTip doesn't work.
https://github.com/react-component/slider/issues/377