### PR TITLE
Fixed a typo on 'slider' example page. ('deperacate' -> 'deprecated')

### DIFF
--- a/examples/slider.js
+++ b/examples/slider.js
@@ -108,7 +108,7 @@ ReactDOM.render(
       />
     </div>
     <div style={style}>
-      <p>Slider with custom handle and track style.<strong>(old api, will be deperacete)</strong></p>
+      <p>Slider with custom handle and track style.<strong>(old api, will be deprecated)</strong></p>
       <Slider
         defaultValue={30}
         maximumTrackStyle={{ backgroundColor: 'red', height: 10 }}


### PR DESCRIPTION
Greetings!

I'm not usually picky when it comes to grammar errors, but I thought this one is quite silly.

> old api, will be <strong>deperacete</strong> -> old api, will be <strong>deprecated</strong>