### PR TITLE
Remove pauseEvent

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -115,7 +115,6 @@ class Range extends React.Component {
   }
 
   onMove(e, position) {
-    utils.pauseEvent(e);
     const props = this.props;
     const state = this.state;
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -94,7 +94,6 @@ class Slider extends React.Component {
   }
 
   onMove(e, position) {
-    utils.pauseEvent(e);
     const { value: oldValue } = this.state;
     const value = this.calcValueByPos(position);
     if (value === oldValue) return;
@@ -106,7 +105,6 @@ class Slider extends React.Component {
     const valueMutator = utils.getKeyboardValueMutator(e);
 
     if (valueMutator) {
-      utils.pauseEvent(e);
       const state = this.state;
       const oldValue = state.value;
       const mutatedValue = valueMutator(oldValue, this.props);

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -109,7 +109,6 @@ export default function createSlider(Component) {
       this.removeDocumentEvents();
       this.onStart(position);
       this.addDocumentMouseEvents();
-      utils.pauseEvent(e);
     }
 
     onTouchStart = (e) => {
@@ -126,7 +125,6 @@ export default function createSlider(Component) {
       }
       this.onStart(position);
       this.addDocumentTouchEvents();
-      utils.pauseEvent(e);
     }
 
     onFocus = (e) => {
@@ -135,7 +133,6 @@ export default function createSlider(Component) {
         const handlePosition = utils.getHandleCenterPosition(vertical, e.target);
         this.dragOffset = 0;
         this.onStart(handlePosition);
-        utils.pauseEvent(e);
         if (onFocus) {
           onFocus(e);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,11 +67,6 @@ export function ensureValuePrecision(val, props) {
     parseFloat(closestPoint.toFixed(getPrecision(step)));
 }
 
-export function pauseEvent(e) {
-  e.stopPropagation();
-  e.preventDefault();
-}
-
 export function getKeyboardValueMutator(e) {
   switch (e.keyCode) {
     case keyCode.UP:


### PR DESCRIPTION
Pausing events can break the normal browser behavior for other inputs in the DOM. For example, focused inputs will fail to blur when interacting with a slider. This can cause unexpected user behavior in the browser.

I'm opening this PR to facilitate discussion, but if you'd like to merge that's totally okay.

Fixes #349