### PR TITLE
Add window.scrollX to fix bug with incorrectly calculated value with scrolled page

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -217,7 +217,7 @@ export default function createSlider(Component) {
       const slider = this.sliderRef;
       const rect = slider.getBoundingClientRect();
 
-      return this.props.vertical ? rect.top : (rect.left + window.scrollX);
+      return this.props.vertical ? rect.top : (rect.left + window.pageXOffset);
     }
 
     getSliderLength() {

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -217,7 +217,7 @@ export default function createSlider(Component) {
       const slider = this.sliderRef;
       const rect = slider.getBoundingClientRect();
 
-      return this.props.vertical ? rect.top : rect.left;
+      return this.props.vertical ? rect.top : (rect.left + window.scrollX);
     }
 
     getSliderLength() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ export function getHandleCenterPosition(vertical, handle) {
   const coords = handle.getBoundingClientRect();
   return vertical ?
     coords.top + (coords.height * 0.5) :
-    coords.left + (coords.width * 0.5);
+    window.pageXOffset + coords.left + (coords.width * 0.5);
 }
 
 export function ensureValueInRange(val, { max, min }) {


### PR DESCRIPTION
When I use horizontal slider, and page is scrolled, clicking to slider incorrectly calculates new value:

This is reproducible on the slider demo page http://react-component.github.io/slider/examples/handle.html

![slider-gif](https://user-images.githubusercontent.com/3725595/38190224-f67c63c0-366b-11e8-8190-bcb3c7b4b652.gif)

_Unfortunately, cursor is not displayed, but I'm clicking to the slider and handle is placed in incorrect place after click._

How to reproduce

1. Open a [demo page](http://react-component.github.io/slider/examples/handle.html)
2. Resize it until horizontal scroll is displayed
3. Scroll a little bit horizontally
4. Click by mouse on any point of sliders

Result: value is incorrectly calculated and slider jumps to incorrect position, not where mouse was clicked

Expected result: mouse click point exactly the same as where handle of the slider is placed.

Proposed solution adds `window.scrollX` in order to have exactly the same values, not matter of scrolled position.

Related info: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

> The amount of scrolling that has been done of the viewport area (or any other scrollable element) is taken into account when computing the bounding rectangle. This means that the rectangle's boundary edges (top, left, bottom, and right) change their values every time the scrolling position changes (because their values are relative to the viewport and not absolute). If you need the bounding rectangle relative to the top-left corner of the document, just add the current scrolling position to the top and left properties (these can be obtained using window.scrollX and window.scrollY) to get a bounding rectangle which is independent from the current scrolling position.