### PR TITLE
Add zoom property to Slider

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -30,7 +30,7 @@ export default function createSlider(Component) {
       handle: PropTypes.func,
       dots: PropTypes.bool,
       vertical: PropTypes.bool,
-      zoom: PropTypes.float,
+      zoom: PropTypes.number,
       style: PropTypes.object,
       minimumTrackStyle: PropTypes.object, // just for compatibility, will be deperecate
       maximumTrackStyle: PropTypes.object, // just for compatibility, will be deperecate

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -30,6 +30,7 @@ export default function createSlider(Component) {
       handle: PropTypes.func,
       dots: PropTypes.bool,
       vertical: PropTypes.bool,
+      zoom: PropTypes.float,
       style: PropTypes.object,
       minimumTrackStyle: PropTypes.object, // just for compatibility, will be deperecate
       maximumTrackStyle: PropTypes.object, // just for compatibility, will be deperecate
@@ -62,6 +63,7 @@ export default function createSlider(Component) {
       disabled: false,
       dots: false,
       vertical: false,
+      zoom: 1.0,
       trackStyle: [{}],
       handleStyle: [{}],
       railStyle: {},
@@ -97,12 +99,12 @@ export default function createSlider(Component) {
     onMouseDown = (e) => {
       if (e.button !== 0) { return; }
 
-      const isVertical = this.props.vertical;
-      let position = utils.getMousePosition(isVertical, e);
+      const { vertical, zoom } = this.props;
+      let position = utils.getMousePosition(vertical, zoom, e);
       if (!utils.isEventFromHandle(e, this.handlesRefs)) {
         this.dragOffset = 0;
       } else {
-        const handlePosition = utils.getHandleCenterPosition(isVertical, e.target);
+        const handlePosition = utils.getHandleCenterPosition(vertical, e.target);
         this.dragOffset = position - handlePosition;
         position = handlePosition;
       }
@@ -114,12 +116,12 @@ export default function createSlider(Component) {
     onTouchStart = (e) => {
       if (utils.isNotTouchEvent(e)) return;
 
-      const isVertical = this.props.vertical;
-      let position = utils.getTouchPosition(isVertical, e);
+      const { vertical, zoom } = this.props;
+      let position = utils.getTouchPosition(vertical, zoom, e);
       if (!utils.isEventFromHandle(e, this.handlesRefs)) {
         this.dragOffset = 0;
       } else {
-        const handlePosition = utils.getHandleCenterPosition(isVertical, e.target);
+        const handlePosition = utils.getHandleCenterPosition(vertical, e.target);
         this.dragOffset = position - handlePosition;
         position = handlePosition;
       }
@@ -181,7 +183,8 @@ export default function createSlider(Component) {
         this.onEnd();
         return;
       }
-      const position = utils.getMousePosition(this.props.vertical, e);
+      const { vertical, zoom } = this.props;
+      const position = utils.getMousePosition(vertical, zoom, e);
       this.onMove(e, position - this.dragOffset);
     }
 
@@ -191,7 +194,8 @@ export default function createSlider(Component) {
         return;
       }
 
-      const position = utils.getTouchPosition(this.props.vertical, e);
+      const { vertical, zoom } = this.props;
+      const position = utils.getTouchPosition(vertical, zoom, e);
       this.onMove(e, position - this.dragOffset);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,12 +35,12 @@ export function getPrecision(step) {
   return precision;
 }
 
-export function getMousePosition(vertical, e) {
-  return vertical ? e.clientY : e.pageX;
+export function getMousePosition(vertical, zoom, e) {
+  return (vertical ? e.clientY : e.pageX) / zoom;
 }
 
-export function getTouchPosition(vertical, e) {
-  return vertical ? e.touches[0].clientY : e.touches[0].pageX;
+export function getTouchPosition(vertical, zoom, e) {
+  return (vertical ? e.touches[0].clientY : e.touches[0].pageX) / zoom;
 }
 
 export function getHandleCenterPosition(vertical, handle) {


### PR DESCRIPTION
This makes click and touch events work on pages that have a custom zoom scale.
We assume a default value of 1, which leaves the Slider working just as before in case the prop is not passed by the component.