### PR TITLE
Add more aria attributes to the handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ The following APIs are shared by Slider and Range.
 | defaultValue | number | `0` | Set initial value of slider. |
 | value | number | - | Set current value of slider. |
 | tabIndex | number | `0` | Set the tabIndex of the slider handle. |
-| aria-label | string | - | Set the `aria-label` attribute on the slider handle.  |
-| aria-labelledby | string | - | Set the `aria-labelledby` attribute on the slider handle. |
-| ariaValueTextFormatter | (value) => string | - | A function to set the `aria-valuetext` attribute on the slider handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
+| ariaLabelForHandle | string | - | Set the `aria-label` attribute on the slider handle.  |
+| ariaLabelledByForHandle | string | - | Set the `aria-labelledby` attribute on the slider handle. |
+| ariaValueTextFormatterForHandle | (value) => string | - | A function to set the `aria-valuetext` attribute on the slider handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
 
 ### Range
 
@@ -136,9 +136,9 @@ The following APIs are shared by Slider and Range.
 | defaultValue | `number[]` | `[0, 0]` | Set initial positions of handles. |
 | value | `number[]` | | Set current positions of handles. |
 | tabIndex | number[] | `[0, 0]` | Set the tabIndex of each handle. |
-| aria-label | Array[string] | - | Set the `aria-label` attribute on each handle. |
-| aria-labelledby | Array[string] | - | Set the `aria-labelledby` attribute on each handle. |
-| ariaValueTextFormatter | Array[(value) => string] | - | A function to set the `aria-valuetext` attribute on each handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
+| ariaLabelGroupForHandles | Array[string] | - | Set the `aria-label` attribute on each handle. |
+| ariaLabelledByGroupForHandles | Array[string] | - | Set the `aria-labelledby` attribute on each handle. |
+| ariaValueTextFormatterGroupForHandles | Array[(value) => string] | - | A function to set the `aria-valuetext` attribute on each handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
 | count | number | `1` | Determine how many ranges to render, and multiple handles will be rendered (number + 1). |
 | allowCross | boolean | `true` | `allowCross` could be set as `true` to allow those handles to cross. |
 | pushable | boolean or number | `false` | `pushable` could be set as `true` to allow pushing of surrounding handles when moving a handle. When set to a number, the number will be the minimum ensured distance between handles. Example: ![](http://i.giphy.com/l46Cs36c9HrHMExoc.gif) |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ The following APIs are shared by Slider and Range.
 | defaultValue | number | `0` | Set initial value of slider. |
 | value | number | - | Set current value of slider. |
 | tabIndex | number | `0` | Set the tabIndex of the slider handle. |
+| aria-label | string | - | Set the `aria-label` attribute on the slider handle.  |
+| aria-labelledby | string | - | Set the `aria-labelledby` attribute on the slider handle. |
+| ariaValueTextFormatter | (value) => string | - | A function to set the `aria-valuetext` attribute on the slider handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
 
 ### Range
 
@@ -133,6 +136,9 @@ The following APIs are shared by Slider and Range.
 | defaultValue | `number[]` | `[0, 0]` | Set initial positions of handles. |
 | value | `number[]` | | Set current positions of handles. |
 | tabIndex | number[] | `[0, 0]` | Set the tabIndex of each handle. |
+| aria-label | Array[string] | - | Set the `aria-label` attribute on each handle. |
+| aria-labelledby | Array[string] | - | Set the `aria-labelledby` attribute on each handle. |
+| ariaValueTextFormatter | Array[(value) => string] | - | A function to set the `aria-valuetext` attribute on each handle. It receives the current value of the slider and returns a formatted string describing the value. See [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices-1.1/#slider) for more information. |
 | count | number | `1` | Determine how many ranges to render, and multiple handles will be rendered (number + 1). |
 | allowCross | boolean | `true` | `allowCross` could be set as `true` to allow those handles to cross. |
 | pushable | boolean or number | `false` | `pushable` could be set as `true` to allow pushing of surrounding handles when moving a handle. When set to a number, the number will be the minimum ensured distance between handles. Example: ![](http://i.giphy.com/l46Cs36c9HrHMExoc.gif) |

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -62,7 +62,20 @@ export default class Handle extends React.Component {
 
   render() {
     const {
-      prefixCls, vertical, reverse, offset, style, disabled, min, max, value, tabIndex, ...restProps
+      prefixCls,
+      vertical,
+      reverse,
+      offset,
+      style,
+      disabled,
+      min,
+      max,
+      value,
+      tabIndex,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      ariaValueTextFormatter,
+      ...restProps
     } = this.props;
 
     const className = classNames(
@@ -90,6 +103,11 @@ export default class Handle extends React.Component {
       _tabIndex = null;
     }
 
+    let ariaValueText;
+    if (ariaValueTextFormatter) {
+      ariaValueText = ariaValueTextFormatter(value);
+    }
+
     return (
       <div
         ref={this.setHandleRef}
@@ -107,6 +125,9 @@ export default class Handle extends React.Component {
         aria-valuemax={max}
         aria-valuenow={value}
         aria-disabled={!!disabled}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-valuetext={ariaValueText}
       />
     );
   }
@@ -124,4 +145,7 @@ Handle.propTypes = {
   value: PropTypes.number,
   tabIndex: PropTypes.number,
   reverse: PropTypes.bool,
+  'aria-label': PropTypes.string,
+  'aria-labelledby': PropTypes.string,
+  ariaValueTextFormatter: PropTypes.func,
 };

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -72,8 +72,8 @@ export default class Handle extends React.Component {
       max,
       value,
       tabIndex,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
+      ariaLabel,
+      ariaLabelledBy,
       ariaValueTextFormatter,
       ...restProps
     } = this.props;
@@ -145,7 +145,7 @@ Handle.propTypes = {
   value: PropTypes.number,
   tabIndex: PropTypes.number,
   reverse: PropTypes.bool,
-  'aria-label': PropTypes.string,
-  'aria-labelledby': PropTypes.string,
+  ariaLabel: PropTypes.string,
+  ariaLabelledBy: PropTypes.string,
   ariaValueTextFormatter: PropTypes.func,
 };

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -46,9 +46,9 @@ class Range extends React.Component {
     tabIndex: PropTypes.arrayOf(PropTypes.number),
     min: PropTypes.number,
     max: PropTypes.number,
-    'aria-label': PropTypes.arrayOf(PropTypes.string),
-    'aria-labelledby': PropTypes.arrayOf(PropTypes.string),
-    ariaValueTextFormatter: PropTypes.arrayOf(PropTypes.func),
+    ariaLabelGroupForHandles: PropTypes.arrayOf(PropTypes.string),
+    ariaLabelledByGroupForHandles: PropTypes.arrayOf(PropTypes.string),
+    ariaValueTextFormatterGroupForHandles: PropTypes.arrayOf(PropTypes.func),
   };
 
   static defaultProps = {
@@ -56,9 +56,9 @@ class Range extends React.Component {
     allowCross: true,
     pushable: false,
     tabIndex: [],
-    'aria-label': [],
-    'aria-labelledby': [],
-    ariaValueTextFormatter: [],
+    ariaLabelGroupForHandles: [],
+    ariaLabelledByGroupForHandles: [],
+    ariaValueTextFormatterGroupForHandles: [],
   };
 
   constructor(props) {
@@ -399,9 +399,9 @@ class Range extends React.Component {
       trackStyle,
       handleStyle,
       tabIndex,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      ariaValueTextFormatter,
+      ariaLabelGroupForHandles,
+      ariaLabelledByGroupForHandles,
+      ariaValueTextFormatterGroupForHandles,
     } = this.props;
 
     const offsets = bounds.map(v => this.calcOffset(v));
@@ -430,9 +430,9 @@ class Range extends React.Component {
         disabled,
         style: handleStyle[i],
         ref: h => this.saveHandle(i, h),
-        'aria-label': ariaLabel[i],
-        'aria-labelledby': ariaLabelledBy[i],
-        ariaValueTextFormatter: ariaValueTextFormatter[i],
+        ariaLabel: ariaLabelGroupForHandles[i],
+        ariaLabelledBy: ariaLabelledByGroupForHandles[i],
+        ariaValueTextFormatter: ariaValueTextFormatterGroupForHandles[i],
       })
     });
 

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -46,6 +46,9 @@ class Range extends React.Component {
     tabIndex: PropTypes.arrayOf(PropTypes.number),
     min: PropTypes.number,
     max: PropTypes.number,
+    'aria-label': PropTypes.arrayOf(PropTypes.string),
+    'aria-labelledby': PropTypes.arrayOf(PropTypes.string),
+    ariaValueTextFormatter: PropTypes.arrayOf(PropTypes.func),
   };
 
   static defaultProps = {
@@ -53,6 +56,9 @@ class Range extends React.Component {
     allowCross: true,
     pushable: false,
     tabIndex: [],
+    'aria-label': [],
+    'aria-labelledby': [],
+    ariaValueTextFormatter: [],
   };
 
   constructor(props) {
@@ -393,6 +399,9 @@ class Range extends React.Component {
       trackStyle,
       handleStyle,
       tabIndex,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      ariaValueTextFormatter,
     } = this.props;
 
     const offsets = bounds.map(v => this.calcOffset(v));
@@ -421,6 +430,9 @@ class Range extends React.Component {
         disabled,
         style: handleStyle[i],
         ref: h => this.saveHandle(i, h),
+        'aria-label': ariaLabel[i],
+        'aria-labelledby': ariaLabelledBy[i],
+        ariaValueTextFormatter: ariaValueTextFormatter[i],
       })
     });
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -16,6 +16,9 @@ class Slider extends React.Component {
     reverse: PropTypes.bool,
     min: PropTypes.number,
     max: PropTypes.number,
+    'aria-label': PropTypes.string,
+    'aria-labelledby': PropTypes.string,
+    ariaValueTextFormatter: PropTypes.func,
   };
 
   constructor(props) {
@@ -153,6 +156,9 @@ class Slider extends React.Component {
       trackStyle,
       handleStyle,
       tabIndex,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      ariaValueTextFormatter,
       min,
       max,
       reverse,
@@ -173,6 +179,9 @@ class Slider extends React.Component {
       reverse,
       index: 0,
       tabIndex,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      ariaValueTextFormatter,
       style: handleStyle[0] || handleStyle,
       ref: h => this.saveHandle(0, h),
     });

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -16,9 +16,9 @@ class Slider extends React.Component {
     reverse: PropTypes.bool,
     min: PropTypes.number,
     max: PropTypes.number,
-    'aria-label': PropTypes.string,
-    'aria-labelledby': PropTypes.string,
-    ariaValueTextFormatter: PropTypes.func,
+    ariaLabelForHandle: PropTypes.string,
+    ariaLabelledByForHandle: PropTypes.string,
+    ariaValueTextFormatterForHandle: PropTypes.func,
   };
 
   constructor(props) {
@@ -156,9 +156,9 @@ class Slider extends React.Component {
       trackStyle,
       handleStyle,
       tabIndex,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      ariaValueTextFormatter,
+      ariaLabelForHandle,
+      ariaLabelledByForHandle,
+      ariaValueTextFormatterForHandle,
       min,
       max,
       reverse,
@@ -179,9 +179,9 @@ class Slider extends React.Component {
       reverse,
       index: 0,
       tabIndex,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      ariaValueTextFormatter,
+      ariaLabel: ariaLabelForHandle,
+      ariaLabelledBy: ariaLabelledByForHandle,
+      ariaValueTextFormatter: ariaValueTextFormatterForHandle,
       style: handleStyle[0] || handleStyle,
       ref: h => this.saveHandle(0, h),
     });

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -235,6 +235,26 @@ describe('Range', () => {
     expect(wrapper.instance().getSlider().state.bounds).toEqual([39, 40]);
   });
 
+  it('sets aria-label on the handles', () => {
+    // eslint-disable-next-line jsx-a11y/aria-proptypes
+    const wrapper = mount(<Range aria-label={['Some Label', 'Some other Label']} />);
+    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-label')).toEqual('Some Label');
+    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-label')).toEqual('Some other Label');
+  });
+
+  it('sets aria-labelledby on the handles', () => {
+    // eslint-disable-next-line jsx-a11y/aria-proptypes
+    const wrapper = mount(<Range aria-labelledby={['some_id', 'some_other_id']} />);
+    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-labelledby')).toEqual('some_id');
+    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-labelledby')).toEqual('some_other_id');
+  });
+
+  it('sets aria-valuetext on the handles', () => {
+    const wrapper = mount(<Range min={0} max={5} defaultValue={[1, 3]} ariaValueTextFormatter={[(value) => `${value} of something`, (value) => `${value} of something else`]} />);
+    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-valuetext')).toEqual('1 of something');
+    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-valuetext')).toEqual('3 of something else');
+  });
+
   describe('focus & blur', () => {
     let container;
 

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -236,21 +236,19 @@ describe('Range', () => {
   });
 
   it('sets aria-label on the handles', () => {
-    // eslint-disable-next-line jsx-a11y/aria-proptypes
-    const wrapper = mount(<Range aria-label={['Some Label', 'Some other Label']} />);
+    const wrapper = mount(<Range ariaLabelGroupForHandles={['Some Label', 'Some other Label']} />);
     expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-label')).toEqual('Some Label');
     expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-label')).toEqual('Some other Label');
   });
 
   it('sets aria-labelledby on the handles', () => {
-    // eslint-disable-next-line jsx-a11y/aria-proptypes
-    const wrapper = mount(<Range aria-labelledby={['some_id', 'some_other_id']} />);
+    const wrapper = mount(<Range ariaLabelledByGroupForHandles={['some_id', 'some_other_id']} />);
     expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-labelledby')).toEqual('some_id');
     expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-labelledby')).toEqual('some_other_id');
   });
 
   it('sets aria-valuetext on the handles', () => {
-    const wrapper = mount(<Range min={0} max={5} defaultValue={[1, 3]} ariaValueTextFormatter={[(value) => `${value} of something`, (value) => `${value} of something else`]} />);
+    const wrapper = mount(<Range min={0} max={5} defaultValue={[1, 3]} ariaValueTextFormatterGroupForHandles={[(value) => `${value} of something`, (value) => `${value} of something else`]} />);
     expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-valuetext')).toEqual('1 of something');
     expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-valuetext')).toEqual('3 of something else');
   });

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -239,17 +239,17 @@ describe('Slider', () => {
   });
 
   it('sets aria-label on the handle', () => {
-    const wrapper = mount(<Slider aria-label="Some Label" />);
+    const wrapper = mount(<Slider ariaLabelForHandle="Some Label" />);
     expect(wrapper.find('.rc-slider-handle').at(1).prop('aria-label')).toEqual('Some Label');
   });
 
   it('sets aria-labelledby on the handle', () => {
-    const wrapper = mount(<Slider aria-labelledby="some_id" />);
+    const wrapper = mount(<Slider ariaLabelledByForHandle="some_id" />);
     expect(wrapper.find('.rc-slider-handle').at(1).prop('aria-labelledby')).toEqual('some_id');
   });
 
   it('sets aria-valuetext on the handle', () => {
-    const wrapper = mount(<Slider min={0} max={5} defaultValue={3} ariaValueTextFormatter={(value) => `${value} of something`} />);
+    const wrapper = mount(<Slider min={0} max={5} defaultValue={3} ariaValueTextFormatterForHandle={(value) => `${value} of something`} />);
     const handle = wrapper.find('.rc-slider-handle').at(1);
 
     expect(handle.prop('aria-valuetext')).toEqual('3 of something');

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -238,6 +238,28 @@ describe('Slider', () => {
     });
   });
 
+  it('sets aria-label on the handle', () => {
+    const wrapper = mount(<Slider aria-label="Some Label" />);
+    expect(wrapper.find('.rc-slider-handle').at(1).prop('aria-label')).toEqual('Some Label');
+  });
+
+  it('sets aria-labelledby on the handle', () => {
+    const wrapper = mount(<Slider aria-labelledby="some_id" />);
+    expect(wrapper.find('.rc-slider-handle').at(1).prop('aria-labelledby')).toEqual('some_id');
+  });
+
+  it('sets aria-valuetext on the handle', () => {
+    const wrapper = mount(<Slider min={0} max={5} defaultValue={3} ariaValueTextFormatter={(value) => `${value} of something`} />);
+    const handle = wrapper.find('.rc-slider-handle').at(1);
+
+    expect(handle.prop('aria-valuetext')).toEqual('3 of something');
+
+    wrapper.simulate('focus');
+    handle.simulate('keyDown', { keyCode: keyCode.RIGHT });
+
+    expect(wrapper.find('.rc-slider-handle').at(1).props()['aria-valuetext']).toEqual('4 of something');
+  });
+
   describe('focus & blur', () => {
     let container;
 


### PR DESCRIPTION
Adds the option to set the following aria attributes on the slider/range handle:

* `aria-label`
* `aria-labelledby`
* `aria-valuetext` (via the `ariaValueTextFormatter` prop)

For more information on using aria attributes with sliders, see:

https://www.w3.org/TR/wai-aria-practices-1.1/#slider

These are added as props on the `Handle` component.  I also added them as props to `Slider` and `Range` -- they just get passed through to the `Handle`.  If you think it's adding too much clutter to `Slider` and `Range`, we could drop those props and have people use a handle generator function to pass them to the `Handle`.

If the props aren't set, the attributes are omitted from the handle element.

Also added info about the props to the readme, and some tests to make sure the attributes get set on the handle element when the props are passed in.