### PR TITLE
Touch direction locking

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -27,7 +27,6 @@
   padding: 5px 0;
   width: 100%;
   border-radius: @border-radius-base;
-  touch-action: none;
   .borderBox();
 
   &-rail {
@@ -58,7 +57,6 @@
     border-radius: 50%;
     border: solid 2px tint(@primary-color, 50%);
     background-color: #fff;
-    touch-action: pan-x;
 
     &:hover {
       border-color: tint(@primary-color, 20%);
@@ -143,6 +141,14 @@
       cursor: not-allowed!important;
     }
   }
+
+  &-dragging {
+     touch-action: none;
+
+     .@{prefixClass}-handle {
+         touch-action: pan-x;
+     }
+  }
 }
 
 .@{prefixClass}-vertical {
@@ -165,7 +171,6 @@
     &-handle {
       margin-left: -5px;
       margin-bottom: -7px;
-      touch-action: pan-y;
     }
 
     &-mark {

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -193,6 +193,11 @@ export default function createSlider(Component) {
         return;
       }
 
+      window.rightDirection = utils.isRightDirection(e, this.props.vertical);
+      if (!utils.isRightDirection(e, this.props.vertical)) {
+        return;
+      }
+
       const position = utils.getTouchPosition(this.props.vertical, e);
       this.onMove(e, position - this.dragOffset);
     }

--- a/src/createSliderWithTooltip.jsx
+++ b/src/createSliderWithTooltip.jsx
@@ -43,10 +43,10 @@ export default function createSliderWithTooltip(Component) {
         visible = visible || false,
         ...restTooltipProps,
       } = tipProps;
-      
+
       let handleStyleWithIndex = handleStyle[0];
       if (handleStyle[index]) {
-          handleStyleWithIndex = handleStyle[index];
+        handleStyleWithIndex = handleStyle[index];
       }
 
       return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,3 +90,69 @@ export function getKeyboardValueMutator(e) {
     default: return undefined;
   }
 }
+
+// http://hammerjs.github.io/api/#directions
+export const DIRECTION_NONE = 1;     // 00001
+export const DIRECTION_LEFT = 2;     // 00010
+export const DIRECTION_RIGHT = 4;    // 00100
+export const DIRECTION_UP = 8;       // 01000
+export const DIRECTION_DOWN = 16;    // 10000
+
+export const DIRECTION_HORIZONTAL = DIRECTION_LEFT | DIRECTION_RIGHT;   // 00110 6
+export const DIRECTION_VERTICAL = DIRECTION_UP | DIRECTION_DOWN;        // 11000 24
+export const DIRECTION_ALL = DIRECTION_HORIZONTAL | DIRECTION_VERTICAL; // 11110  30
+
+/**
+ * @private
+ * get the direction between two points
+ * @param {Number} x
+ * @param {Number} y
+ * @return {Number} direction
+ */
+export function getDirection(x, y) {
+  if (x === y) {
+    return DIRECTION_NONE;
+  }
+  if (Math.abs(x) >= Math.abs(y)) {
+    return x < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
+  }
+  return y < 0 ? DIRECTION_UP : DIRECTION_DOWN;
+}
+
+export function getDirectionEventName(direction) {
+  let name;
+  switch (direction) {
+    case DIRECTION_NONE:
+      break;
+    case DIRECTION_LEFT:
+      name = 'left';
+      break;
+    case DIRECTION_RIGHT:
+      name = 'right';
+      break;
+    case DIRECTION_UP:
+      name = 'up';
+      break;
+    case DIRECTION_DOWN:
+      name = 'down';
+      break;
+    default:
+  }
+  return name;
+}
+
+export function getTouchDirection(startTouches, touches) {
+  const { x: x1, y: y1 } = startTouches[0];
+  const { x: x2, y: y2 } = touches[0];
+  const deltaX = x2 - x1;
+  const deltaY = y2 - y1;
+  return getDirection(deltaX, deltaY);
+}
+
+export function isRightDirection(startTouches, touches, vertical) {
+  const direction = getTouchDirection(startTouches, touches);
+  if (vertical) {
+    return direction === DIRECTION_UP || direction === DIRECTION_DOWN;
+  }
+  return direction === DIRECTION_LEFT || direction === DIRECTION_RIGHT;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,10 +98,6 @@ export const DIRECTION_RIGHT = 4;    // 00100
 export const DIRECTION_UP = 8;       // 01000
 export const DIRECTION_DOWN = 16;    // 10000
 
-export const DIRECTION_HORIZONTAL = DIRECTION_LEFT | DIRECTION_RIGHT;   // 00110 6
-export const DIRECTION_VERTICAL = DIRECTION_UP | DIRECTION_DOWN;        // 11000 24
-export const DIRECTION_ALL = DIRECTION_HORIZONTAL | DIRECTION_VERTICAL; // 11110  30
-
 /**
  * @private
  * get the direction between two points
@@ -119,31 +115,9 @@ export function getDirection(x, y) {
   return y < 0 ? DIRECTION_UP : DIRECTION_DOWN;
 }
 
-export function getDirectionEventName(direction) {
-  let name;
-  switch (direction) {
-    case DIRECTION_NONE:
-      break;
-    case DIRECTION_LEFT:
-      name = 'left';
-      break;
-    case DIRECTION_RIGHT:
-      name = 'right';
-      break;
-    case DIRECTION_UP:
-      name = 'up';
-      break;
-    case DIRECTION_DOWN:
-      name = 'down';
-      break;
-    default:
-  }
-  return name;
-}
-
 export function getTouchDirection(startTouches, touches) {
-  const { x: x1, y: y1 } = startTouches[0];
-  const { x: x2, y: y2 } = touches[0];
+  const { clientX: x1, clientY: y1 } = startTouches[0];
+  const { clientX: x2, clientY: y2 } = touches[0];
   const deltaX = x2 - x1;
   const deltaY = y2 - y1;
   return getDirection(deltaX, deltaY);


### PR DESCRIPTION
Fixes issue #308. There's still 3 tests failing and all are related to `dragOffset`, but I don't really know what's wrong, so it would be nice if someone could have a look.

### Biggest changes
#### Moved a big part of the code in onTouchStart to onFirstTouchMove to be called once within onTouchMove
**Reason:** It is impossible to determine the direction of the swipe in onTouchStart because there's only one touch point to work with. Because of that, we have to postpone the initialization of the component to the first call of onTouchMove, because at that point we have a second touch point to calculate the swipe direction with. If the swipe is in the wrong direction, the component will never be initialized, and page scroll will work as expected.

#### Added dragging state with matching class `${prefixCls}-dragging`
**Reason:** because of the `touch-action: none` and `touch-action: pan-x` styles, page scrolling is interrupted regardless of what the component does. I added a new css class to set these styles after the component initialized to fix scrolling issues.