### PR TITLE
Use current value in Range when clipping to min/max

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -64,7 +64,7 @@ class Range extends React.Component {
 
     this.setState({ bounds: nextBounds });
 
-    if (bounds.some(v => utils.isValueOutOfRange(v, nextProps))) {
+    if (value.some(v => utils.isValueOutOfRange(v, nextProps))) {
       const newValues = value.map((v) => {
         return utils.ensureValueInRange(v, nextProps);
       });

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -88,6 +88,14 @@ describe('Range', () => {
     expect(props.onChange).toHaveBeenCalledWith([0.01, 500]);
   });
 
+  it('should only update bounds if they are out of range', () => {
+    const props = { min: 0, max: 10000, value: [0.01, 10000], onChange: jest.fn() };
+    const range = mount(<Range {...props} />);
+    range.setProps({ min: 0, max: 500, value: [0.01, 466] });
+
+    expect(props.onChange).toHaveBeenCalledTimes(0);
+  });
+
   // https://github.com/react-component/slider/pull/256
   it('should handle mutli handle mouseEnter correctly', () => {
     const wrapper = mount(<RangeWithTooltip min={0} max={1000} defaultValue={[50, 55]} />);


### PR DESCRIPTION
closes #466 

On figuring out how the code works, I'm not sure what the previous test case was testing:
https://github.com/gpinhey/slider/blob/110ef4e48e7c5262db21bd0dc43bdbe6dcead2ef/tests/Range.test.js#L83-L89
When `step` is set, shouldn't it be expected that the `value` prop will be aligned to that step? While the test confirms that `onChange` is fired with the values not aligned to step, the component's `nextBounds` are different from what is communicated via `onChange`.
I think `onChange` should be fired whenever `nextBounds` was modified from the provided `value` (whether controlled via the `value` prop or uncontrolled via `state.bounds`).