### PR TITLE
Added onAfterChange call on mark label click

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -183,6 +183,7 @@ export default function createSlider(Component) {
     onClickMarkLabel = (e, value) => {
       e.stopPropagation();
       this.onChange({ value });
+      this.onEnd();
     }
 
     getSliderStart() {

--- a/tests/common/createSlider.test.js
+++ b/tests/common/createSlider.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len, no-undef */
 import React from 'react';
-import {mount} from 'enzyme';
-import Slider, {Range} from '../../src';
+import { mount } from 'enzyme';
+import Slider, { Range } from '../../src';
 
 const setWidth = (object, width) => {
   // https://github.com/tmpvar/jsdom/commit/0cdb2efcc69b6672dc2928644fc0172df5521176

--- a/tests/common/createSlider.test.js
+++ b/tests/common/createSlider.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len, no-undef */
 import React from 'react';
-import { mount } from 'enzyme';
-import Slider, { Range } from '../../src';
+import {mount} from 'enzyme';
+import Slider, {Range} from '../../src';
 
 const setWidth = (object, width) => {
   // https://github.com/tmpvar/jsdom/commit/0cdb2efcc69b6672dc2928644fc0172df5521176
@@ -222,5 +222,28 @@ describe('createSlider', () => {
       preventDefault() {},
     });
     expect(wrapper.instance().dragOffset).toBe(0);
+  });
+
+  it('should call onAfterChange when clicked on mark label', () => {
+    const labelId = 'to-be-clicked';
+    const marks = {
+      0: 'some other label',
+      100: <span id={labelId}>some label</span>
+    };
+
+    const sliderOnAfterChange = jest.fn();
+    const sliderWrapper = mount(<Slider value={0} marks={marks} onAfterChange={sliderOnAfterChange} />);
+    const sliderHandleWrapper = sliderWrapper.find(`#${labelId}`).at(0);
+    sliderHandleWrapper.simulate('mousedown');
+    sliderHandleWrapper.simulate('mouseup');
+    expect(sliderOnAfterChange).toHaveBeenCalled();
+
+    const rangeOnAfterChange = jest.fn();
+    const rangeWrapper = mount(<Range value={[0, 1]} marks={marks} onAfterChange={rangeOnAfterChange} />);
+    const rangeHandleWrapper = rangeWrapper.find(`#${labelId}`).at(0);
+    rangeHandleWrapper.simulate('mousedown');
+    rangeHandleWrapper.simulate('mouseup');
+
+    expect(rangeOnAfterChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Currently there is no invocation of `onAfterChange` when there is a click on the label of a mark.
To me this looks like a bug. I expect the same behaviour as clicking on the dot (representing the value) itself.

In order to achieve the expected invocation I call `onEnd` when a mark label is clicked. Since I only use the Slider I'm not really sure if the expected behaviour for the Range component might be different.