### PR TITLE
Add keyboard support for components that have fixed values and no step

### DIFF
--- a/examples/handle.js
+++ b/examples/handle.js
@@ -34,6 +34,10 @@ ReactDOM.render(
       <Slider min={0} max={20} defaultValue={3} handle={handle} />
     </div>
     <div style={wrapperStyle}>
+      <p>Slider with fixed values</p>
+      <Slider min={20} defaultValue={20} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />
+    </div>
+    <div style={wrapperStyle}>
       <p>Range with custom handle</p>
       <Range min={0} max={20} defaultValue={[3, 10]} tipFormatter={value => `${value}%`} />
     </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,15 +72,32 @@ export function pauseEvent(e) {
   e.preventDefault();
 }
 
+export function calculateNextValue(func, value, props) {
+  const operations = {
+    increase: (a, b) => a + b,
+    decrease: (a, b) => a - b,
+  };
+
+  const indexToGet = operations[func](Object.keys(props.marks).indexOf(JSON.stringify(value)), 1);
+  const keyToGet = Object.keys(props.marks)[indexToGet];
+
+  if (props.step) {
+    return operations[func](value, props.step);
+  } else if (!!Object.keys(props.marks).length && !!props.marks[keyToGet]) {
+    return props.marks[keyToGet];
+  }
+  return value;
+}
+
 export function getKeyboardValueMutator(e) {
   switch (e.keyCode) {
     case keyCode.UP:
     case keyCode.RIGHT:
-      return (value, props) => value + props.step;
+      return (value, props) => calculateNextValue('increase', value, props);
 
     case keyCode.DOWN:
     case keyCode.LEFT:
-      return (value, props) => value - props.step;
+      return (value, props) => calculateNextValue('decrease', value, props);
 
     case keyCode.END: return (value, props) => props.max;
     case keyCode.HOME: return (value, props) => props.min;

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -105,6 +105,68 @@ describe('Slider', () => {
     expect(wrapper.state('value')).toBe(100);
   });
 
+  describe.only('when component has fixed values', () => {
+    it('increases the value when key "up" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={40} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.UP });
+
+      expect(wrapper.state('value')).toBe(100);
+    });
+
+    it('increases the value when key "right" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={40} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.RIGHT });
+
+      expect(wrapper.state('value')).toBe(100);
+    });
+
+    it('decreases the value when key "down" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={40} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.DOWN });
+
+      expect(wrapper.state('value')).toBe(20);
+    });
+
+    it('decreases the value when key "left" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={40} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.LEFT });
+
+      expect(wrapper.state('value')).toBe(20);
+    });
+
+    it('sets the value to minimum when key "home" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={100} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.HOME });
+
+      expect(wrapper.state('value')).toBe(20);
+    });
+
+    it('sets the value to maximum when the key "end" is pressed', () => {
+      const wrapper = mount(<Slider min={20} defaultValue={20} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />);
+      const handler = wrapper.find('.rc-slider-handle').at(1);
+
+      wrapper.simulate('focus');
+      handler.simulate('keyDown', { keyCode: keyCode.END });
+
+      expect(wrapper.state('value')).toBe(100);
+    });
+  });
+
   describe('focus & blur', () => {
     let container;
 


### PR DESCRIPTION
We currently have a component that may have fixed values, i.e the user can choose between the values `10, 30, 60, 90, 100`.

To achieve that, the component takes the following props:
````
<Slider 
  marks={{10: 10, 30: 30, 60: 60, 90: 90, 100: 100}}
  min={10}
  step={null}
/>
````

This breaks the current accessibility support, which increases/decreases the component's value according to the steps.
It would be amazing if we could implement support to change it to the next mark when step is set to null.