### PR TITLE
Remove reset handler state onEnd

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -115,9 +115,6 @@ class Range extends React.Component {
   }
 
   onEnd = () => {
-    this.setState({
-      handle: null,
-    });
     this.removeDocumentEvents();
     this.props.onAfterChange(this.getValue());
   }


### PR DESCRIPTION
Fixes #503 

I found this was added here: https://github.com/react-component/slider/commit/ac0e5cb86fa56e956d5cd6d670473f9c4b2c44a1 
In this case, more dealbreaker than the solution. If somebody can please review, so we can have stable thing.