### PR TITLE
Critical Bug Fix: Keyboard listeners for range slider

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -214,7 +214,7 @@ class Range extends React.Component {
     const { state, props } = this;
     const nextBounds = [...state.bounds];
     nextBounds[state.handle] = value;
-    let nextHandle = state.handle;
+    let nextHandle = state.handle || state.recent;
     if (props.pushable !== false) {
       this.pushSurroundingHandles(nextBounds, nextHandle);
     } else if (props.allowCross) {


### PR DESCRIPTION
When using [the range slider ](http://react-component.github.io/slider/examples/range.html), the current handle is not determined correctly when using the keyboard to move the handles.
As a result, when using range-slider by using **arrow keys** the whole component crashes.
I made a quick fix to use the recent handle if the current handle is not found.