### PR TITLE
Add ability for pass null in tabIndex prop

### DIFF
--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -73,14 +73,15 @@ export default class Handle extends React.Component {
       ...postionStyle,
     };
 
+    let _tabIndex = tabIndex || 0;
+    if (disabled || tabIndex === null) {
+      _tabIndex = null;
+    }
+
     return (
       <div
         ref={this.setHandleRef}
-        tabIndex= {disabled
-          ? null
-          : tabIndex === null
-            ? null
-            : (tabIndex || 0)}
+        tabIndex= {_tabIndex}
         {...restProps}
         className={className}
         style={elStyle}

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -76,7 +76,11 @@ export default class Handle extends React.Component {
     return (
       <div
         ref={this.setHandleRef}
-        tabIndex= {disabled ? null : (tabIndex || 0)}
+        tabIndex= {disabled
+          ? null
+          : tabIndex === null
+            ? null
+            : (tabIndex || 0)}
         {...restProps}
         className={className}
         style={elStyle}

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -353,7 +353,9 @@ class Range extends React.Component {
       value: v,
       dragging: handle === i,
       index: i,
-      tabIndex: tabIndex[i] || 0,
+      tabIndex: tabIndex[i] === null
+        ? null
+        : (tabIndex[i] || 0),
       min,
       max,
       disabled,

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -342,26 +342,30 @@ class Range extends React.Component {
     const offsets = bounds.map(v => this.calcOffset(v));
 
     const handleClassName = `${prefixCls}-handle`;
-    const handles = bounds.map((v, i) => handleGenerator({
-      className: classNames({
-        [handleClassName]: true,
-        [`${handleClassName}-${i + 1}`]: true,
-      }),
-      prefixCls,
-      vertical,
-      offset: offsets[i],
-      value: v,
-      dragging: handle === i,
-      index: i,
-      tabIndex: tabIndex[i] === null
-        ? null
-        : (tabIndex[i] || 0),
-      min,
-      max,
-      disabled,
-      style: handleStyle[i],
-      ref: h => this.saveHandle(i, h),
-    }));
+    const handles = bounds.map((v, i) => {
+      let _tabIndex = tabIndex[i] || 0;
+      if (disabled || tabIndex[i] === null) {
+          _tabIndex = null;
+      }
+      return handleGenerator({
+        className: classNames({
+          [handleClassName]: true,
+          [`${handleClassName}-${i + 1}`]: true,
+        }),
+        prefixCls,
+        vertical,
+        offset: offsets[i],
+        value: v,
+        dragging: handle === i,
+        index: i,
+        tabIndex: _tabIndex,
+        min,
+        max,
+        disabled,
+        style: handleStyle[i],
+        ref: h => this.saveHandle(i, h),
+      })
+    });
 
     const tracks = bounds.slice(0, -1).map((_, index) => {
       const i = index + 1;

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -35,6 +35,14 @@ describe('Range', () => {
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().tabIndex).toEqual(2);
   });
 
+  it('should render Range without tabIndex (equal null) correctly', () => {
+    const wrapper = mount(<Range tabIndex={[null, null]} />);
+    const firstHandle = wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).getDOMNode();
+    const secondHandle = wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).getDOMNode();
+    expect(firstHandle.hasAttribute('tabIndex')).toEqual(false);
+    expect(secondHandle.hasAttribute('tabIndex')).toEqual(false);
+  });
+
   it('should render Multi-Range with value correctly', () => {
     const wrapper = mount(<Range count={3} value={[0, 25, 50, 75]} />);
     expect(wrapper.state('bounds')[0]).toBe(0);

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -30,6 +30,12 @@ describe('Slider', () => {
     expect(wrapper.find('.rc-slider-handle').at(1).props().tabIndex).toEqual(1);
   });
 
+  it('should allow tabIndex to be set on Handle via Slider and be equal null', () => {
+    const wrapper = mount(<Slider tabIndex={null} />);
+    const handle = wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).getDOMNode();
+    expect(handle.hasAttribute('tabIndex')).toEqual(false);
+  });
+
   it('increases the value when key "up" is pressed', () => {
     const wrapper = mount(<Slider defaultValue={50} />);
     const handler = wrapper.find('.rc-slider-handle').at(1);


### PR DESCRIPTION
When I click on the mark in the slider a focus event occurs. And if I want to click on another mark, then I will have to click twice. It is not right. As a solution, we should be able to pass a null. In this case, the attribute tabindex will not be added and the focus events and blur will not occur.