### PR TITLE
Allow passing children to Handle component

### DIFF
--- a/examples/handle.js
+++ b/examples/handle.js
@@ -34,6 +34,14 @@ ReactDOM.render(
       <Slider min={0} max={20} defaultValue={3} handle={handle} />
     </div>
     <div style={wrapperStyle}>
+      <p>Slider with custom component in handle</p>
+      <Slider min={0} max={20} defaultValue={3} handle={(props) => (
+        <Handle {...props} style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <span style={{ fontSize: 10 }}>{ props.value }</span>
+        </Handle>
+      )} />
+    </div>
+    <div style={wrapperStyle}>
       <p>Slider with fixed values</p>
       <Slider min={20} defaultValue={20} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />
     </div>

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -57,7 +57,7 @@ export default class Handle extends React.Component {
 
   render() {
     const {
-      prefixCls, vertical, offset, style, disabled, min, max, value, tabIndex, ...restProps
+      prefixCls, vertical, offset, style, disabled, min, max, value, tabIndex, children, ...restProps
     } = this.props;
 
     const className = classNames(
@@ -89,13 +89,16 @@ export default class Handle extends React.Component {
         aria-valuemax={max}
         aria-valuenow={value}
         aria-disabled={!!disabled}
-      />
+      >
+        { children }
+      </div>
     );
   }
 }
 
 Handle.propTypes = {
   prefixCls: PropTypes.string,
+  children: PropTypes.node,
   className: PropTypes.string,
   vertical: PropTypes.bool,
   offset: PropTypes.number,


### PR DESCRIPTION
Fixes #436 

This allows the developer to pass custom components to be rendered within the Handle. I have added an example where the value of the slider is shown within the handle.