### PR TITLE
Prevent slider from returning value higher than max

### DIFF
--- a/examples/slider.js
+++ b/examples/slider.js
@@ -81,12 +81,15 @@ class DynamicBounds extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      min: 0,
+      min: 1,
       max: 100,
+      step: 10,
+      value: 1,
     };
   }
   onSliderChange = (value) => {
     log(value);
+    this.setState({value});
   }
   onMinChange = (e) => {
     this.setState({
@@ -98,16 +101,28 @@ class DynamicBounds extends React.Component {
       max: +e.target.value || 100,
     });
   }
+  onStepChange = (e) => {
+    this.setState({
+      step: +e.target.value || 1,
+    });
+  }
   render() {
+    const labelStyle = { minWidth: '60px', display: 'inline-block' };
+    const inputStyle = { marginBottom: '10px'};
     return (
       <div>
-        <label>Min: </label>
-        <input type="number" value={this.state.min} onChange={this.onMinChange} />
+        <label style={labelStyle}>Min: </label>
+        <input type="number" value={this.state.min} onChange={this.onMinChange} style={inputStyle} />
         <br />
-        <label>Max: </label>
-        <input type="number" value={this.state.max} onChange={this.onMaxChange} />
+        <label style={labelStyle}>Max: </label>
+        <input type="number" value={this.state.max} onChange={this.onMaxChange} style={inputStyle} />
+        <br />
+        <label style={labelStyle}>Step: </label>
+        <input type="number" value={this.state.step} onChange={this.onStepChange} style={inputStyle} />
         <br /><br />
-        <Slider defaultValue={50} min={this.state.min} max={this.state.max}
+        <label style={labelStyle}>Value: </label><span>{this.state.value}</span>
+        <br /><br />
+        <Slider value={this.state.value} min={this.state.min} max={this.state.max} step={this.state.step}
           onChange={this.onSliderChange}
         />
       </div>
@@ -190,7 +205,7 @@ ReactDOM.render(
       <NullableSlider />
     </div>
     <div style={style}>
-      <p>Slider with dynamic `min` `max`</p>
+      <p>Slider with dynamic `min` `max` `step`</p>
       <DynamicBounds />
     </div>
   </div>

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -32,11 +32,11 @@ class Slider extends React.Component {
     if (utils.isDev()) {
       warning(
         !('minimumTrackStyle' in props),
-        'minimumTrackStyle will be deprecate, please use trackStyle instead.'
+        'minimumTrackStyle will be deprecated, please use trackStyle instead.'
       );
       warning(
         !('maximumTrackStyle' in props),
-        'maximumTrackStyle will be deprecate, please use railStyle instead.'
+        'maximumTrackStyle will be deprecated, please use railStyle instead.'
       );
     }
   }
@@ -66,11 +66,12 @@ class Slider extends React.Component {
   onChange(state) {
     const props = this.props;
     const isNotControlled = !('value' in props);
+    const nextState = state.value > this.props.max ? {...state, value: this.props.max} : state;
     if (isNotControlled) {
-      this.setState(state);
+      this.setState(nextState);
     }
 
-    const changedValue = state.value;
+    const changedValue = nextState.value;
     props.onChange(changedValue);
   }
 


### PR DESCRIPTION
When using min, max and step values like 
min = 1
max = 99
step = 10
then Slider may end up returning a value higher than max.

Example: slide down to 1 then slide up to max - value becomes 101

Also updated 'dynamic bounds' slider example

The bugfix: Slider.jsx, line 69