### PR TITLE
onAfterChange won't trigger for left handle when clicking on track - issue #529

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -118,7 +118,7 @@ class Range extends React.Component {
     const { handle } = this.state;
     this.removeDocumentEvents();
 
-    if (handle || force) {
+    if (handle !== null || force) {
       this.props.onAfterChange(this.getValue());
     }
 


### PR DESCRIPTION
Fixing issue described in [529](https://github.com/react-component/slider/issues/529)

