### PR TITLE
Fix deprecated prop name

### DIFF
--- a/examples/slider.js
+++ b/examples/slider.js
@@ -160,8 +160,8 @@ ReactDOM.render(
       <p>Slider with custom handle and track style.<strong>(old api, will be deprecated)</strong></p>
       <Slider
         defaultValue={30}
-        maximumTrackStyle={{ backgroundColor: 'red', height: 10 }}
-        minimumTrackStyle={{ backgroundColor: 'blue', height: 10 }}
+        railStyle={{ backgroundColor: 'red', height: 10 }}
+        trackStyle={{ backgroundColor: 'blue', height: 10 }}
         handleStyle={{
           borderColor: 'blue',
           height: 28,


### PR DESCRIPTION
Hi,

in `examples/slider.js`, deprecated props `maximumTrackStyle` and `minimumTrackStyle` are still used.

In Typescript environment, these props cannot be used anymore, and this may cause some confusions.

This PR fixes this problem.

Thanks.