### PR TITLE
Fix Slider Mark click values for onAfterChange

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -188,7 +188,7 @@ export default function createSlider(Component) {
     onClickMarkLabel = (e, value) => {
       e.stopPropagation();
       this.onChange({ value });
-      this.onEnd(true);
+      this.setState({ value }, () => this.onEnd(true));
     }
 
     getSliderStart() {


### PR DESCRIPTION
Fixes a case where clicking a `Mark` on a `Slider` causes `onAfterChange` handler to be called with old value, because `setState` isn't done with updates yet.

This edit ensures `onEnd` is called only after the change has been applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/react-component/slider/554)
<!-- Reviewable:end -->
