### PR TITLE
Support coloring track < minRange by adding a zero-index track / trackStyle

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -386,24 +386,37 @@ class Range extends React.Component {
       })
     });
 
+    const getTrackClassName = (i) => classNames({
+      [`${prefixCls}-track`]: true,
+      [`${prefixCls}-track-${i}`]: true,
+    });
+
     const tracks = bounds.slice(0, -1).map((_, index) => {
       const i = index + 1;
-      const trackClassName = classNames({
-        [`${prefixCls}-track`]: true,
-        [`${prefixCls}-track-${i}`]: true,
-      });
       return (
         <Track
-          className={trackClassName}
+          className={getTrackClassName(i)}
           vertical={vertical}
           included={included}
           offset={offsets[i - 1]}
           length={offsets[i] - offsets[i - 1]}
-          style={trackStyle[index]}
+          style={trackStyle[index + 1]}
           key={i}
         />
       );
     });
+
+    tracks.unshift(
+      <Track
+        className={getTrackClassName(0)}
+        vertical={vertical}
+        included={included}
+        offset={0}
+        length={offsets[0]}
+        style={trackStyle[0]}
+        key={0}
+      />
+    );
 
     return { tracks, handles };
   }

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -25,9 +25,13 @@ describe('Range', () => {
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.left).toMatch('0%');
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.left).toMatch('50%');
 
-    const trackStyle = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
-    expect(trackStyle.left).toMatch('0%');
-    expect(trackStyle.width).toMatch('50%');
+    const trackStyle0 = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    expect(trackStyle0.left).toMatch('0%');
+    expect(trackStyle0.width).toMatch('0%');
+
+    const trackStyle1 = wrapper.find('.rc-slider-track > .rc-slider-track').at(1).props().style;
+    expect(trackStyle1.left).toMatch('0%');
+    expect(trackStyle1.width).toMatch('50%');
   });
 
   it('should render Range with tabIndex correctly', () => {
@@ -66,15 +70,19 @@ describe('Range', () => {
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(2).props().style.left).toMatch('50%');
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(3).props().style.left).toMatch('75%');
 
-    const track1Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    const track0Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    expect(track0Style.left).toMatch('0%');
+    expect(track0Style.width).toMatch('0%');
+
+    const track1Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(1).props().style;
     expect(track1Style.left).toMatch('0%');
     expect(track1Style.width).toMatch('25%');
 
-    const track2Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(1).props().style;
+    const track2Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(2).props().style;
     expect(track2Style.left).toMatch('25%');
     expect(track2Style.width).toMatch('25%');
 
-    const track3Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(2).props().style;
+    const track3Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(3).props().style;
     expect(track3Style.left).toMatch('50%');
     expect(track3Style.width).toMatch('25%');
   });

--- a/tests/__snapshots__/Range.test.js.snap
+++ b/tests/__snapshots__/Range.test.js.snap
@@ -8,6 +8,10 @@ exports[`Range should render Multi-Range with correct DOM structure 1`] = `
     class="rc-slider-rail"
   />
   <div
+    class="rc-slider-track rc-slider-track-0"
+    style="left:0%;width:0%"
+  />
+  <div
     class="rc-slider-track rc-slider-track-1"
     style="left:0%;width:0%"
   />
@@ -74,6 +78,10 @@ exports[`Range should render Range with correct DOM structure 1`] = `
 >
   <div
     class="rc-slider-rail"
+  />
+  <div
+    class="rc-slider-track rc-slider-track-0"
+    style="left:0%;width:0%"
   />
   <div
     class="rc-slider-track rc-slider-track-1"


### PR DESCRIPTION
It appears there is currently no way to color the minimum track in a range. To solve this, I created an additional zero-index track which uses the existing `trackStyle` property.

This would change the coloring for existing implementations so I don't expect it to be merged, but figured it would be helpful to someone :-)

Before:

<img width="417" alt="Screen Shot 2019-05-14 at 15 55 55" src="https://user-images.githubusercontent.com/810323/57737701-72b6d200-7661-11e9-899d-50cd12e0a366.png">


After:

<img width="410" alt="Screen Shot 2019-05-14 at 15 56 14" src="https://user-images.githubusercontent.com/810323/57737706-78141c80-7661-11e9-83a6-301345a596b9.png">

