### PR TITLE
Fix #575: Range issue with pushable={0}

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -172,7 +172,7 @@ class Range extends React.Component {
     const { bounds } = this.state;
     let closestBound = 0;
     for (let i = 1; i < bounds.length - 1; ++i) {
-      if (value > bounds[i]) { closestBound = i; }
+      if (value >= bounds[i]) { closestBound = i; }
     }
     if (Math.abs(bounds[closestBound + 1] - value) < Math.abs(bounds[closestBound] - value)) {
       closestBound += 1;


### PR DESCRIPTION
This bug fix was quite simple. Please review it and let me know if I need to change anything.

I'm just a little worried about this part : `if (Math.abs(bounds[closestBound + 1] - value) < Math.abs(bounds[closestBound] - value))`. I don't quite get why it's here and if my changes can affect it.