### PR TITLE
fix: reset dragging value on blur

### DIFF
--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -153,7 +153,6 @@ export default function createSlider(Component) {
 
     onBlur = (e) => {
       const { onBlur } = this.props;
-      this.onEnd();
       if (onBlur) {
         onBlur(e);
       }


### PR DESCRIPTION
![dragging-reset](https://user-images.githubusercontent.com/50441480/61049702-6e9afc80-a3e5-11e9-855c-8a72ae9a464f.gif)

The dragging value wasn't correctly reseted after a click on the slider.

I had the remove the call to "onEnd()" in the onBlur to fix it.