### PR TITLE
Removed focus from handle onmouseup event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ lib
 es
 /coverage
 yarn.lock
+package-lock.json

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -232,6 +232,10 @@ export default function createSlider(Component) {
       this.onMouseMoveListener && this.onMouseMoveListener.remove();
       this.onMouseUpListener && this.onMouseUpListener.remove();
       /* eslint-enable no-unused-expressions */
+
+      // added to remove focus from handle which causing not closing the tooltip mentioned in issue id number #579
+      this.blur();
+
     }
 
     focus() {


### PR DESCRIPTION
added this.blur(); to remove focus from handle onmouseup event. This will resolve the issue id #579 as well.