### PR TITLE
Update prop chart to include prefixCls

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following APIs are shared by Slider and Range.
 
 | Name         | Type    | Default | Description |
 | ------------ | ------- | ------- | ----------- |
+| prefixCls | string | `rc-tooltip` | Prefix class name |
 | className | string | `''` | Additional CSS class for the root DOM node |
 | min | number | `0` | The minimum value of the slider |
 | max | number | `100` | The maximum value of the slider |


### PR DESCRIPTION
Hey! 
Noticed that `prefixCls` is a prop that is exposed, but not documented. So I added it to the props chart in the readMe.
Here's an example code snippet of it in use, with a screenshot of the HTML to show that it is passing in the `prefixCls` to the className.
```
  <Slider
    prefixCls="predixClsTest"
  />
```
![image](https://user-images.githubusercontent.com/16307737/67982940-a70f5200-fbf1-11e9-9642-6e9deed34b98.png)