### PR TITLE
Make Handle component propagate onBlur, onMouseDown and onKeyDown events

### DIFF
--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -34,17 +34,26 @@ export default class Handle extends React.Component {
     }
   }
 
-  handleMouseDown = () => {
+  handleMouseDown = (event) => {
     // fix https://github.com/ant-design/ant-design/issues/15324
     this.focus();
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(event);
+    }
   }
 
-  handleBlur = () => {
+  handleBlur = (event) => {
     this.setClickFocus(false);
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
   }
 
-  handleKeyDown = () => {
+  handleKeyDown = (event) => {
     this.setClickFocus(false);
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(event);
+    }
   }
 
   clickFocus() {


### PR DESCRIPTION
Currently if passing these event handler to a Handle component in a custom handle, they will be swallowed by Handle's internal event handlers. This PR simply propagates the events to the passed event handler if they exist.