### PR TITLE
trackStart prop for Slider component

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The following APIs are shared by Slider and Range.
 | ------------ | ------- | ------- | ----------- |
 | defaultValue | number | `0` | Set initial value of slider. |
 | value | number | - | Set current value of slider. |
-| pivot | number | `undefined` | Track starts from this value. If `undefined`, `min` is used. |
+| trackStart | number | `undefined` | Track starts from this value. If `undefined`, `min` is used. |
 | tabIndex | number | `0` | Set the tabIndex of the slider handle. |
 | ariaLabelForHandle | string | - | Set the `aria-label` attribute on the slider handle.  |
 | ariaLabelledByForHandle | string | - | Set the `aria-labelledby` attribute on the slider handle. |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The following APIs are shared by Slider and Range.
 | ------------ | ------- | ------- | ----------- |
 | defaultValue | number | `0` | Set initial value of slider. |
 | value | number | - | Set current value of slider. |
-| trackStart | number | `undefined` | Track starts from this value. If `undefined`, `min` is used. |
+| startPoint | number | `undefined` | Track starts from this value. If `undefined`, `min` is used. |
 | tabIndex | number | `0` | Set the tabIndex of the slider handle. |
 | ariaLabelForHandle | string | - | Set the `aria-label` attribute on the slider handle.  |
 | ariaLabelledByForHandle | string | - | Set the `aria-labelledby` attribute on the slider handle. |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The following APIs are shared by Slider and Range.
 | ------------ | ------- | ------- | ----------- |
 | defaultValue | number | `0` | Set initial value of slider. |
 | value | number | - | Set current value of slider. |
+| pivot | number | `undefined` | Track starts from this value. If `undefined`, `min` is used. |
 | tabIndex | number | `0` | Set the tabIndex of the slider handle. |
 | ariaLabelForHandle | string | - | Set the `aria-label` attribute on the slider handle.  |
 | ariaLabelledByForHandle | string | - | Set the `aria-labelledby` attribute on the slider handle. |

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -137,8 +137,8 @@ ReactDOM.render(
       <Slider onChange={log} />
     </div>
     <div style={style}>
-      <p>Basic Slider, `trackStart=50`</p>
-      <Slider onChange={log} trackStart={50} />
+      <p>Basic Slider, `startPoint=50`</p>
+      <Slider onChange={log} startPoint={50} />
     </div>
     <div style={style}>
       <p>Slider reverse</p>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -137,8 +137,8 @@ ReactDOM.render(
       <Slider onChange={log} />
     </div>
     <div style={style}>
-      <p>Basic Slider, `pivot=50`</p>
-      <Slider onChange={log} pivot={50} />
+      <p>Basic Slider, `trackStart=50`</p>
+      <Slider onChange={log} trackStart={50} />
     </div>
     <div style={style}>
       <p>Slider reverse</p>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -137,6 +137,10 @@ ReactDOM.render(
       <Slider onChange={log} />
     </div>
     <div style={style}>
+      <p>Basic Slider, `pivot=50`</p>
+      <Slider onChange={log} pivot={50} />
+    </div>
+    <div style={style}>
       <p>Slider reverse</p>
       <Slider onChange={log} reverse min={20} max={60}/>
     </div>

--- a/examples/vertical.js
+++ b/examples/vertical.js
@@ -32,8 +32,8 @@ ReactDOM.render(
       <Slider vertical min={-10} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
-      <p>Slider with marks, `step=null` and `trackStart=0`</p>
-      <Slider vertical min={-10} trackStart={0} marks={marks} step={null} onChange={log} defaultValue={20} />
+      <p>Slider with marks, `step=null` and `startPoint=0`</p>
+      <Slider vertical min={-10} startPoint={0} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
       <p>Reverse Slider with marks, `step=null`</p>

--- a/examples/vertical.js
+++ b/examples/vertical.js
@@ -32,6 +32,10 @@ ReactDOM.render(
       <Slider vertical min={-10} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
+      <p>Slider with marks, `step=null` and `pivot=0`</p>
+      <Slider vertical min={-10} pivot={0} marks={marks} step={null} onChange={log} defaultValue={20} />
+    </div>
+    <div style={style}>
       <p>Reverse Slider with marks, `step=null`</p>
       <Slider vertical min={-10} marks={marks} step={null} onChange={log} defaultValue={20} reverse />
     </div>

--- a/examples/vertical.js
+++ b/examples/vertical.js
@@ -32,8 +32,8 @@ ReactDOM.render(
       <Slider vertical min={-10} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
-      <p>Slider with marks, `step=null` and `pivot=0`</p>
-      <Slider vertical min={-10} pivot={0} marks={marks} step={null} onChange={log} defaultValue={20} />
+      <p>Slider with marks, `step=null` and `trackStart=0`</p>
+      <Slider vertical min={-10} trackStart={0} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
     <div style={style}>
       <p>Reverse Slider with marks, `step=null`</p>

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -16,7 +16,7 @@ class Slider extends React.Component {
     reverse: PropTypes.bool,
     min: PropTypes.number,
     max: PropTypes.number,
-    trackStart: PropTypes.number,
+    startPoint: PropTypes.number,
     ariaLabelForHandle: PropTypes.string,
     ariaLabelledByForHandle: PropTypes.string,
     ariaValueTextFormatterForHandle: PropTypes.func,
@@ -162,7 +162,7 @@ class Slider extends React.Component {
       ariaValueTextFormatterForHandle,
       min,
       max,
-      trackStart,
+      startPoint,
       reverse,
       handle: handleGenerator,
     } = this.props;
@@ -188,7 +188,7 @@ class Slider extends React.Component {
       ref: h => this.saveHandle(0, h),
     });
 
-    const trackOffset = trackStart !== undefined ? this.calcOffset(trackStart) : 0;
+    const trackOffset = startPoint !== undefined ? this.calcOffset(startPoint) : 0;
     const _trackStyle = trackStyle[0] || trackStyle;
     const track = (
       <Track

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -16,7 +16,7 @@ class Slider extends React.Component {
     reverse: PropTypes.bool,
     min: PropTypes.number,
     max: PropTypes.number,
-    pivot: PropTypes.number,
+    trackStart: PropTypes.number,
     ariaLabelForHandle: PropTypes.string,
     ariaLabelledByForHandle: PropTypes.string,
     ariaValueTextFormatterForHandle: PropTypes.func,
@@ -162,7 +162,7 @@ class Slider extends React.Component {
       ariaValueTextFormatterForHandle,
       min,
       max,
-      pivot,
+      trackStart,
       reverse,
       handle: handleGenerator,
     } = this.props;
@@ -188,7 +188,7 @@ class Slider extends React.Component {
       ref: h => this.saveHandle(0, h),
     });
 
-    const trackOffset = pivot !== undefined ? this.calcOffset(pivot) : 0;
+    const trackOffset = trackStart !== undefined ? this.calcOffset(trackStart) : 0;
     const _trackStyle = trackStyle[0] || trackStyle;
     const track = (
       <Track

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -16,6 +16,7 @@ class Slider extends React.Component {
     reverse: PropTypes.bool,
     min: PropTypes.number,
     max: PropTypes.number,
+    pivot: PropTypes.number,
     ariaLabelForHandle: PropTypes.string,
     ariaLabelledByForHandle: PropTypes.string,
     ariaValueTextFormatterForHandle: PropTypes.func,
@@ -161,6 +162,7 @@ class Slider extends React.Component {
       ariaValueTextFormatterForHandle,
       min,
       max,
+      pivot,
       reverse,
       handle: handleGenerator,
     } = this.props;
@@ -186,15 +188,16 @@ class Slider extends React.Component {
       ref: h => this.saveHandle(0, h),
     });
 
+    const trackOffset = pivot !== undefined ? this.calcOffset(pivot) : 0;
     const _trackStyle = trackStyle[0] || trackStyle;
     const track = (
       <Track
         className={`${prefixCls}-track`}
         vertical={vertical}
         included={included}
-        offset={0}
+        offset={trackOffset}
         reverse={reverse}
-        length={offset}
+        length={offset - trackOffset}
         style={{
           ...minimumTrackStyle,
           ..._trackStyle,

--- a/src/common/Track.jsx
+++ b/src/common/Track.jsx
@@ -2,7 +2,14 @@
 import React from 'react';
 
 const Track = (props) => {
-  const { className, included, vertical, offset, length, style, reverse } = props;
+  const { className, included, vertical, style } = props;
+  let { length, offset, reverse } = props;
+  if (length < 0) {
+    reverse = !reverse;
+    length = Math.abs(length);
+    offset = 100 - offset;
+  }
+
   const positonStyle = vertical ? {
     [reverse ? 'top' : 'bottom']: `${offset}%`,
     [reverse ? 'bottom' : 'top']: 'auto',

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -17,7 +17,7 @@ export default function createSlider(Component) {
       ...Component.propTypes,
       min: PropTypes.number,
       max: PropTypes.number,
-      pivot: PropTypes.number,
+      trackStart: PropTypes.number,
       step: PropTypes.number,
       marks: PropTypes.object,
       included: PropTypes.bool,

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -17,7 +17,7 @@ export default function createSlider(Component) {
       ...Component.propTypes,
       min: PropTypes.number,
       max: PropTypes.number,
-      trackStart: PropTypes.number,
+      startPoint: PropTypes.number,
       step: PropTypes.number,
       marks: PropTypes.object,
       included: PropTypes.bool,

--- a/src/common/createSlider.jsx
+++ b/src/common/createSlider.jsx
@@ -17,6 +17,7 @@ export default function createSlider(Component) {
       ...Component.propTypes,
       min: PropTypes.number,
       max: PropTypes.number,
+      pivot: PropTypes.number,
       step: PropTypes.number,
       marks: PropTypes.object,
       included: PropTypes.bool,

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -23,8 +23,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('50%');
   });
 
-  it('should render Slider with greater value than pivot correctly', () => {
-    const wrapper = mount(<Slider value={50} pivot={20} />);
+  it('should render Slider correctly where value > trackStart', () => {
+    const wrapper = mount(<Slider value={50} trackStart={20} />);
     expect(wrapper.state('value')).toBe(50);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('50%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
@@ -35,8 +35,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('30%');
   });
 
-  it('should render Slider with lesser value than pivot correctly', () => {
-    const wrapper = mount(<Slider value={40} pivot={60} />);
+  it('should render Slider correctly where value < trackStart', () => {
+    const wrapper = mount(<Slider value={40} trackStart={60} />);
     expect(wrapper.state('value')).toBe(40);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('40%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
@@ -59,8 +59,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('50%');
   });
 
-  it('should render reverse Slider with greater value than pivot correctly', () => {
-    const wrapper = mount(<Slider value={50} pivot={20} reverse />);
+  it('should render reverse Slider correctly where value > trackStart', () => {
+    const wrapper = mount(<Slider value={50} trackStart={20} reverse />);
     expect(wrapper.state('value')).toBe(50);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('50%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');
@@ -71,8 +71,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('30%');
   });
 
-  it('should render reverse Slider with lesser value than pivot correctly', () => {
-    const wrapper = mount(<Slider value={30} pivot={50} reverse />);
+  it('should render reverse Slider correctly where value < trackStart', () => {
+    const wrapper = mount(<Slider value={30} trackStart={50} reverse />);
     expect(wrapper.state('value')).toBe(30);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('30%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -23,8 +23,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('50%');
   });
 
-  it('should render Slider correctly where value > trackStart', () => {
-    const wrapper = mount(<Slider value={50} trackStart={20} />);
+  it('should render Slider correctly where value > startPoint', () => {
+    const wrapper = mount(<Slider value={50} startPoint={20} />);
     expect(wrapper.state('value')).toBe(50);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('50%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
@@ -35,8 +35,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('30%');
   });
 
-  it('should render Slider correctly where value < trackStart', () => {
-    const wrapper = mount(<Slider value={40} trackStart={60} />);
+  it('should render Slider correctly where value < startPoint', () => {
+    const wrapper = mount(<Slider value={40} startPoint={60} />);
     expect(wrapper.state('value')).toBe(40);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('40%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
@@ -59,8 +59,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('50%');
   });
 
-  it('should render reverse Slider correctly where value > trackStart', () => {
-    const wrapper = mount(<Slider value={50} trackStart={20} reverse />);
+  it('should render reverse Slider correctly where value > startPoint', () => {
+    const wrapper = mount(<Slider value={50} startPoint={20} reverse />);
     expect(wrapper.state('value')).toBe(50);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('50%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');
@@ -71,8 +71,8 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('30%');
   });
 
-  it('should render reverse Slider correctly where value < trackStart', () => {
-    const wrapper = mount(<Slider value={30} trackStart={50} reverse />);
+  it('should render reverse Slider correctly where value < startPoint', () => {
+    const wrapper = mount(<Slider value={30} startPoint={50} reverse />);
     expect(wrapper.state('value')).toBe(30);
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('30%');
     expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -23,6 +23,30 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('50%');
   });
 
+  it('should render Slider with greater value than pivot correctly', () => {
+    const wrapper = mount(<Slider value={50} pivot={20} />);
+    expect(wrapper.state('value')).toBe(50);
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('50%');
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
+
+    const trackStyle = wrapper.find('.rc-slider-track').at(1).props().style;
+    expect(trackStyle.left).toMatch('20%');
+    expect(trackStyle.right).toMatch('auto');
+    expect(trackStyle.width).toMatch('30%');
+  });
+
+  it('should render Slider with lesser value than pivot correctly', () => {
+    const wrapper = mount(<Slider value={40} pivot={60} />);
+    expect(wrapper.state('value')).toBe(40);
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('40%');
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('auto');
+
+    const trackStyle = wrapper.find('.rc-slider-track').at(1).props().style;
+    expect(trackStyle.left).toMatch('auto');
+    expect(trackStyle.right).toMatch('40%');
+    expect(trackStyle.width).toMatch('20%');
+  });
+
   it('should render reverse Slider with value correctly', () => {
     const wrapper = mount(<Slider value={50} reverse />);
     expect(wrapper.state('value')).toBe(50);
@@ -33,6 +57,30 @@ describe('Slider', () => {
     expect(trackStyle.right).toMatch('0%');
     expect(trackStyle.left).toMatch('auto');
     expect(trackStyle.width).toMatch('50%');
+  });
+
+  it('should render reverse Slider with greater value than pivot correctly', () => {
+    const wrapper = mount(<Slider value={50} pivot={20} reverse />);
+    expect(wrapper.state('value')).toBe(50);
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('50%');
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');
+
+    const trackStyle = wrapper.find('.rc-slider-track').at(1).props().style;
+    expect(trackStyle.right).toMatch('20%');
+    expect(trackStyle.left).toMatch('auto');
+    expect(trackStyle.width).toMatch('30%');
+  });
+
+  it('should render reverse Slider with lesser value than pivot correctly', () => {
+    const wrapper = mount(<Slider value={30} pivot={50} reverse />);
+    expect(wrapper.state('value')).toBe(30);
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.right).toMatch('30%');
+    expect(wrapper.find('.rc-slider-handle').at(1).props().style.left).toMatch('auto');
+
+    const trackStyle = wrapper.find('.rc-slider-track').at(1).props().style;
+    expect(trackStyle.right).toMatch('auto');
+    expect(trackStyle.left).toMatch('50%');
+    expect(trackStyle.width).toMatch('20%');
   });
 
   it('should render Slider without handle if value is null', () => {


### PR DESCRIPTION
By default the track starts from `min` value in Slider component. With new `trackStart` prop you can define where the track starts from.

Examples:
![horizontal](https://user-images.githubusercontent.com/490260/71582383-b5ef8380-2b12-11ea-9100-b7d19f867b18.jpg)
![vertical](https://user-images.githubusercontent.com/490260/71582394-bf78eb80-2b12-11ea-9be4-28a1c6c9f641.jpg)

See #488 