### PR TITLE
Do not trim-align values when props are changing

### DIFF
--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -87,12 +87,7 @@ class Range extends React.Component {
   static getDerivedStateFromProps(props, state) {
     if ('value' in props || 'min' in props || 'max' in props) {
       const value = props.value || state.bounds;
-      const nextBounds = value.map((v, i) => trimAlignValue({
-        value: v,
-        handle: i,
-        bounds: state.bounds,
-        props,
-      }));
+      const nextBounds = value;
       if (nextBounds.length === state.bounds.length &&
           nextBounds.every((v, i) => v === state.bounds[i])) {
         return null;


### PR DESCRIPTION
When the value (ranges) are controlled (props) the trim-align process may change the new values in a wrong way, for instance [0, 60, 60, 240] produced [60, 60] breaking what the parent container actually passes.