### PR TITLE
Fix floating-point arithmetic issues when props are decimals.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 import { findDOMNode } from 'react-dom';
 import keyCode from 'rc-util/lib/KeyCode';
 
+const MAX_PRECISION_FOR_OPERATIONS = 15;
+
 export function isEventFromHandle(e, handles) {
   try {
     return Object.keys(handles)
@@ -36,13 +38,19 @@ function withPrecision(value, precision) {
 // then round the result to the combined precision
 
 function safeDivideBy(a, b) {
-  const precision = getPrecision(a) + getPrecision(b);
+  const precision = Math.min(
+    getPrecision(a) + getPrecision(b),
+    MAX_PRECISION_FOR_OPERATIONS
+  );
   return precision === 0 ? a / b : withPrecision(a / b, precision);
 }
 
 function safeMultiply(a, b) {
-  const precision = getPrecision(a) + getPrecision(b);
-  return precision === 0 ? a * b : withPrecision(a * b, precision);
+  const precision = Math.min(
+    getPrecision(a) + getPrecision(b),
+    MAX_PRECISION_FOR_OPERATIONS
+  );
+  return withPrecision(a * b, precision);
 }
 
 export function getClosestPoint(val, { marks, step, min, max }) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -38,5 +38,17 @@ describe('utils', () => {
 
       expect(utils.getClosestPoint(value, props)).toBe(96);
     });
+
+    it('should properly handle floating point arithmetic', () => {
+      const value = 5.3;
+      const props = {
+        marks: {},
+        step: 0.05,
+        min: 0,
+        max: 5.3
+      };
+
+      expect(utils.getClosestPoint(value, props)).toBe(5.3);
+    });
   });
 });


### PR DESCRIPTION
Consider the following case:

```
      const value = 5.3;
      const props = {
        marks: {},
        step: 0.05,
        min: 0,
        max: 5.3
      };
```

I would expect the output of `getClosestPoint` to be `5.3`. However, it returns `5.25`.

This is because of floating point arithmetic issues with the function.

I've added a test case and taken a stab at figuring it out, making sure I continue to respect the `Math.floor` logic on `maxSteps`.