### PR TITLE
fix: fix marks position

### DIFF
--- a/src/common/Marks.jsx
+++ b/src/common/Marks.jsx
@@ -39,11 +39,9 @@ const Marks = ({
     };
 
     const leftStyle = {
-      transform: `translateX(-50%)`,
-      msTransform: `translateX(-50%)`,
-      [reverse ? 'right' : 'left']: reverse 
-        ? `${(point - (min / 4)) / range * 100}%`
-        : `${(point - min) / range * 100}%`,
+      transform: `translateX(${reverse ? `50%` : `-50%`})`,
+      msTransform: `translateX(${reverse ? `50%` : `-50%`})`,
+      [reverse ? 'right' : 'left']: `${(point - min) / range * 100}%`
     };
 
     const style = vertical ? bottomStyle : leftStyle;

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -83,6 +83,12 @@ describe('Slider', () => {
     expect(trackStyle.width).toMatch('20%');
   });
 
+  it('should render reverse Slider with marks correctly', () => {
+    const marks = {5:'5', 6:'6', 7:'7', 8:'8', 9:'9', 10:'10'};
+    const wrapper = mount(<Slider value={0} marks={marks} min={5} max={10} reverse />);
+    expect(wrapper.find('.rc-slider-mark-text').at(0).props().style.right).toMatch('0%');
+  });
+
   it('should render Slider without handle if value is null', () => {
     const wrapper = render(<Slider value={null} />);
     expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
在reverse时，设置最小数不为0，可复现bug；
附上reverse前后截图；
![normal](https://user-images.githubusercontent.com/11717862/75560337-ef475f80-5a7f-11ea-8998-2f762508bd7f.png)
![reverse](https://user-images.githubusercontent.com/11717862/75560345-f1a9b980-5a7f-11ea-8b79-49bca46d24b9.png)
