### PR TITLE
fix: fix vertical handle transform

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -128,7 +128,6 @@
       border-color: tint(@primary-color, 50%);
     }
     &-reverse {
-      margin-left: 0;
       margin-right: -4px;
     }
   }

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -86,7 +86,8 @@ export default class Handle extends React.Component {
     );
     const positionStyle = vertical ? {
       [reverse ? 'top' : 'bottom']: `${offset}%`,
-      [reverse ? 'bottom' : 'top']: 'auto'
+      [reverse ? 'bottom' : 'top']: 'auto',
+      transform: reverse ? null : `translateY(+50%)`,
     } : {
       [reverse ? 'right' : 'left']: `${offset}%`,
       [reverse ? 'left' : 'right']: 'auto',

--- a/src/Handle.jsx
+++ b/src/Handle.jsx
@@ -86,8 +86,7 @@ export default class Handle extends React.Component {
     );
     const positionStyle = vertical ? {
       [reverse ? 'top' : 'bottom']: `${offset}%`,
-      [reverse ? 'bottom' : 'top']: 'auto',
-      transform: `translateY(+50%)`,
+      [reverse ? 'bottom' : 'top']: 'auto'
     } : {
       [reverse ? 'right' : 'left']: `${offset}%`,
       [reverse ? 'left' : 'right']: 'auto',


### PR DESCRIPTION
Ref https://github.com/ant-design/ant-design/issues/22128

Before: 

<img width="200" alt="截屏2020-03-1221 33 11" src="https://user-images.githubusercontent.com/12122021/76526852-274f9900-64a9-11ea-8ea6-cdc613a0c6e3.png">

After:

<img width="207" alt="截屏2020-03-1221 32 10" src="https://user-images.githubusercontent.com/12122021/76526848-261e6c00-64a9-11ea-8ede-8a5283be78eb.png">

@afc163 We need to fix this from rc-slider's side.