### PR TITLE
fix: allow step prop to be null for typescript

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -10,7 +10,7 @@ export interface SliderProps extends GenericSliderProps {
   defaultValue?: number;
   min?: number;
   max?: number;
-  step?: number;
+  step?: number | null;
   prefixCls?: string;
   onChange?: (value: number) => void;
   onBeforeChange?: (value: number) => void;


### PR DESCRIPTION
When using null step Slider in Typescript, the linter complains that `step` cannot be null when used:
```
export default () => (
  <div>
       {/*Type 'null' is not assignable to type 'number | undefined'*/}
       <Slider step={null} /> 
    </div>
)
```

In the API is is clearly mentioned that step can be null:
| Name         | Type    | Default | Description |
| ------------ | ------- | ------- | ----------- |
| step | number or `null` | `1` | Value to be added or subtracted on each step the slider makes. Must be greater than zero, and `max` - `min` should be evenly divisible by the step value. <br /> When `marks` is not an empty object, `step` can be set to `null`, to make `marks` as steps. |

This PR is to fix the type definition so that it doesn't show the error above.
