### PR TITLE
Fix Dynamically Decreasing Number of Handles Results in Incorrect Handles

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -132,28 +132,36 @@ class Range extends React.Component<RangeProps, RangeState> {
   }
 
   static getDerivedStateFromProps(props, state) {
-    if ('value' in props || 'min' in props || 'max' in props) {
-      const value = props.value || state.bounds;
-      const nextBounds = value.map((v, i) =>
+    if (!('value' in props || 'min' in props || 'max' in props)) return null;
+
+    const value = props.value || state.bounds;
+    let nextBounds = value.map((v, i) =>
+      trimAlignValue({
+        value: v,
+        handle: i,
+        bounds: state.bounds,
+        props,
+      }),
+    );
+
+    if (state.bounds.length === nextBounds.length) {
+      if (nextBounds.every((v, i) => v === state.bounds[i])) {
+        return null;
+      }
+    } else {
+      nextBounds = value.map((v, i) =>
         trimAlignValue({
           value: v,
           handle: i,
-          bounds: state.bounds,
           props,
         }),
       );
-      if (
-        nextBounds.length === state.bounds.length &&
-        nextBounds.every((v, i) => v === state.bounds[i])
-      ) {
-        return null;
-      }
-      return {
-        ...state,
-        bounds: nextBounds,
-      };
     }
-    return null;
+
+    return {
+      ...state,
+      bounds: nextBounds,
+    };
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -540,7 +540,7 @@ describe('Range', () => {
   });
 
   // Corresponds to the issue described in https://github.com/react-component/slider/issues/690.
-  it('should correctly display a dynamically decreased number of handles', () => {
+  it('should correctly display a dynamically changed number of handles', () => {
     class RangeUnderTest extends React.Component {
       state = {
         handles: [0, 25, 50, 75, 100],
@@ -565,21 +565,32 @@ describe('Range', () => {
     }
 
     const rangeUnderTest = mount(<RangeUnderTest />);
-    rangeUnderTest.setState({ handles: [0, 75, 100] });
+    const verifyHandles = () => {
+      // Has the number of handles that we set.
+      expect(rangeUnderTest.find('div.rc-slider-handle')).toHaveLength(
+        rangeUnderTest.state('handles').length,
+      );
+      // Handles have the values that we set.
+      expect(
+        rangeUnderTest
+          .find('div.rc-slider-handle')
+          .everyWhere(
+            (element, index) =>
+              Number(element.prop('aria-valuenow')) === rangeUnderTest.state('handles')[index],
+          ),
+      ).toEqual(true);
+    };
 
-    // Has the number of handles that we set.
-    expect(rangeUnderTest.find('div.rc-slider-handle')).toHaveLength(
-      rangeUnderTest.state('handles').length,
-    );
-    // Handles have the values that we set.
-    expect(
-      rangeUnderTest
-        .find('div.rc-slider-handle')
-        .everyWhere(
-          (element, index) =>
-            Number(element.prop('aria-valuenow')) === rangeUnderTest.state('handles')[index],
-        ),
-    ).toEqual(true);
+    // Assert that handles are correct initially.
+    verifyHandles();
+
+    // Assert that handles are correct after decreasing their number.
+    rangeUnderTest.setState({ handles: [0, 75, 100] });
+    verifyHandles();
+
+    // Assert that handles are correct after increasing their number.
+    rangeUnderTest.setState({ handles: [0, 25, 75, 100] });
+    verifyHandles();
   });
 
   describe('focus & blur', () => {

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -300,6 +300,46 @@ describe('Range', () => {
     expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-valuetext')).toEqual('3 of something else');
   });
 
+  // Corresponds to the issue described in https://github.com/react-component/slider/issues/690.
+  it('should correctly display a dynamically decreased number of handles', () => {
+    class RangeUnderTest extends React.Component {
+      state = {
+        handles: [0, 25, 50, 75, 100]
+      };
+
+      render() {
+        return (
+          <Range
+            allowCross={false}
+            marks={{
+              0: { label: "0", style: {} },
+              25: { label: "25", style: {} },
+              50: { label: "50", style: {} },
+              75: { label: "75", style: {} },
+              100: { label: "100", style: {} }
+            }}
+            step={null}
+            value={this.state.handles}
+          />
+        );
+      }
+    }
+
+    const rangeUnderTest = mount(<RangeUnderTest />);
+    rangeUnderTest.setState({ handles: [0, 75, 100] });
+
+    // Has the number of handles that we set.
+    expect(rangeUnderTest.find('div.rc-slider-handle')).toHaveLength(rangeUnderTest.state('handles').length);
+    // Handles have the values that we set.
+    expect(
+      rangeUnderTest
+        .find('div.rc-slider-handle')
+        .everyWhere((element, index) =>
+          Number(element.prop('aria-valuenow')) === rangeUnderTest.state('handles')[index]
+        )
+    ).toEqual(true);
+  });
+
   describe('focus & blur', () => {
     let container;
 

--- a/tests/Range.test.js
+++ b/tests/Range.test.js
@@ -22,12 +22,35 @@ describe('Range', () => {
     const wrapper = mount(<Range value={[0, 50]} />);
     expect(wrapper.state('bounds')[0]).toBe(0);
     expect(wrapper.state('bounds')[1]).toBe(50);
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.left).toMatch('0%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.left).toMatch('50%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.right).toMatch('auto');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.right).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().style.left,
+    ).toMatch('0%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.left,
+    ).toMatch('50%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().style.right,
+    ).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.right,
+    ).toMatch('auto');
 
-    const trackStyle = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    const trackStyle = wrapper
+      .find('.rc-slider-track > .rc-slider-track')
+      .at(0)
+      .props().style;
     expect(trackStyle.left).toMatch('0%');
     expect(trackStyle.right).toMatch('auto');
     expect(trackStyle.width).toMatch('50%');
@@ -37,12 +60,35 @@ describe('Range', () => {
     const wrapper = mount(<Range value={[0, 50]} reverse />);
     expect(wrapper.state('bounds')[0]).toBe(0);
     expect(wrapper.state('bounds')[1]).toBe(50);
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.right).toMatch('0%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.right).toMatch('50%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.left).toMatch('auto');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.left).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().style.right,
+    ).toMatch('0%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.right,
+    ).toMatch('50%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().style.left,
+    ).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.left,
+    ).toMatch('auto');
 
-    const trackStyle = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    const trackStyle = wrapper
+      .find('.rc-slider-track > .rc-slider-track')
+      .at(0)
+      .props().style;
     expect(trackStyle.right).toMatch('0%');
     expect(trackStyle.left).toMatch('auto');
     expect(trackStyle.width).toMatch('50%');
@@ -50,14 +96,30 @@ describe('Range', () => {
 
   it('should render Range with tabIndex correctly', () => {
     const wrapper = mount(<Range tabIndex={[1, 2]} />);
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().tabIndex).toEqual(1);
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().tabIndex).toEqual(2);
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().tabIndex,
+    ).toEqual(1);
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().tabIndex,
+    ).toEqual(2);
   });
 
   it('should render Range without tabIndex (equal null) correctly', () => {
     const wrapper = mount(<Range tabIndex={[null, null]} />);
-    const firstHandle = wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).getDOMNode();
-    const secondHandle = wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).getDOMNode();
+    const firstHandle = wrapper
+      .find('.rc-slider-handle > .rc-slider-handle')
+      .at(0)
+      .getDOMNode();
+    const secondHandle = wrapper
+      .find('.rc-slider-handle > .rc-slider-handle')
+      .at(1)
+      .getDOMNode();
     expect(firstHandle.hasAttribute('tabIndex')).toEqual(false);
     expect(secondHandle.hasAttribute('tabIndex')).toEqual(false);
   });
@@ -79,44 +141,96 @@ describe('Range', () => {
     expect(wrapper.state('bounds')[1]).toBe(25);
     expect(wrapper.state('bounds')[2]).toBe(50);
     expect(wrapper.state('bounds')[3]).toBe(75);
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(0).props().style.left).toMatch('0%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.right).toMatch('auto');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.right).toMatch('auto');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(1).props().style.left).toMatch('25%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(2).props().style.left).toMatch('50%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(2).props().style.right).toMatch('auto');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(3).props().style.left).toMatch('75%');
-    expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').at(3).props().style.right).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(0)
+        .props().style.left,
+    ).toMatch('0%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.right,
+    ).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.right,
+    ).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(1)
+        .props().style.left,
+    ).toMatch('25%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(2)
+        .props().style.left,
+    ).toMatch('50%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(2)
+        .props().style.right,
+    ).toMatch('auto');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(3)
+        .props().style.left,
+    ).toMatch('75%');
+    expect(
+      wrapper
+        .find('.rc-slider-handle > .rc-slider-handle')
+        .at(3)
+        .props().style.right,
+    ).toMatch('auto');
 
-    const track1Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(0).props().style;
+    const track1Style = wrapper
+      .find('.rc-slider-track > .rc-slider-track')
+      .at(0)
+      .props().style;
     expect(track1Style.left).toMatch('0%');
     expect(track1Style.right).toMatch('auto');
     expect(track1Style.width).toMatch('25%');
 
-    const track2Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(1).props().style;
+    const track2Style = wrapper
+      .find('.rc-slider-track > .rc-slider-track')
+      .at(1)
+      .props().style;
     expect(track2Style.left).toMatch('25%');
     expect(track2Style.right).toMatch('auto');
     expect(track2Style.width).toMatch('25%');
 
-    const track3Style = wrapper.find('.rc-slider-track > .rc-slider-track').at(2).props().style;
+    const track3Style = wrapper
+      .find('.rc-slider-track > .rc-slider-track')
+      .at(2)
+      .props().style;
     expect(track3Style.left).toMatch('50%');
     expect(track3Style.right).toMatch('auto');
     expect(track3Style.width).toMatch('25%');
   });
 
   it('should update Range correctly in controllered model', () => {
-    class TestParent extends React.Component { // eslint-disable-line
+    class TestParent extends React.Component {
+      // eslint-disable-line
       state = {
         value: [2, 4, 6],
-      }
+      };
+
       getSlider() {
         return this.refs.slider;
       }
+
       render() {
-        return <Range ref="slider" value={this.state.value}/>;
+        return <Range ref="slider" value={this.state.value} />;
       }
     }
-    const wrapper = mount(<TestParent/>);
+    const wrapper = mount(<TestParent />);
 
     expect(wrapper.instance().getSlider().state.bounds.length).toBe(3);
     expect(wrapper.find('.rc-slider-handle > .rc-slider-handle').length).toBe(3);
@@ -144,27 +258,42 @@ describe('Range', () => {
   // https://github.com/react-component/slider/pull/256
   it('should handle mutli handle mouseEnter correctly', () => {
     const wrapper = mount(<RangeWithTooltip min={0} max={1000} defaultValue={[50, 55]} />);
-    wrapper.find('.rc-slider-handle').at(1).simulate('mouseEnter');
+    wrapper
+      .find('.rc-slider-handle')
+      .at(1)
+      .simulate('mouseEnter');
     expect(wrapper.state().visibles[0]).toBe(true);
-    wrapper.find('.rc-slider-handle').at(3).simulate('mouseEnter');
+    wrapper
+      .find('.rc-slider-handle')
+      .at(3)
+      .simulate('mouseEnter');
     expect(wrapper.state().visibles[1]).toBe(true);
-    wrapper.find('.rc-slider-handle').at(1).simulate('mouseLeave');
+    wrapper
+      .find('.rc-slider-handle')
+      .at(1)
+      .simulate('mouseLeave');
     expect(wrapper.state().visibles[0]).toBe(false);
-    wrapper.find('.rc-slider-handle').at(3).simulate('mouseLeave');
+    wrapper
+      .find('.rc-slider-handle')
+      .at(3)
+      .simulate('mouseLeave');
     expect(wrapper.state().visibles[1]).toBe(false);
   });
 
   it('should keep pushable when not allowCross and setState', () => {
-    class CustomizedRange extends React.Component { // eslint-disable-line
+    class CustomizedRange extends React.Component {
+      // eslint-disable-line
       constructor(props) {
         super(props);
         this.state = {
           value: [20, 40],
         };
       }
+
       getSlider() {
         return this.refs.slider;
       }
+
       render() {
         return <Range ref="slider" allowCross={false} value={this.state.value} pushable={10} />;
       }
@@ -184,21 +313,25 @@ describe('Range', () => {
   });
 
   it('should render correctly when allowCross', () => {
-    class CustomizedRange extends React.Component { // eslint-disable-line
+    class CustomizedRange extends React.Component {
+      // eslint-disable-line
       constructor(props) {
         super(props);
         this.state = {
           value: [20, 40],
         };
       }
-      onChange = (value) => {
+
+      onChange = value => {
         this.setState({
           value,
         });
-      }
+      };
+
       getSlider() {
         return this.refs.slider;
       }
+
       render() {
         return <Range ref="slider" onChange={this.onChange} value={this.state.value} />;
       }
@@ -208,7 +341,7 @@ describe('Range', () => {
       map[event] = cb;
     });
 
-    const mockRect = (wrapper) => {
+    const mockRect = wrapper => {
       wrapper.instance().getSlider().sliderRef.getBoundingClientRect = () => ({
         left: 0,
         width: 100,
@@ -223,31 +356,61 @@ describe('Range', () => {
 
     expect(wrapper.instance().getSlider().state.bounds).toEqual([20, 40]);
 
-    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 0, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
-    map.mousemove({ type: 'mousemove', pageX: 60, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
+    wrapper.find('.rc-slider').simulate('mouseDown', {
+      button: 0,
+      pageX: 0,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
+    map.mousemove({
+      type: 'mousemove',
+      pageX: 60,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
 
     expect(wrapper.instance().getSlider().state.bounds).toEqual([40, 60]);
-    expect(wrapper.find('.rc-slider-handle-2').at(1).getDOMNode().className).toContain('rc-slider-handle-dragging');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-2')
+        .at(1)
+        .getDOMNode().className,
+    ).toContain('rc-slider-handle-dragging');
   });
 
   it('should keep pushable with pushable s defalutValue when not allowCross and setState', () => {
-    class CustomizedRange extends React.Component { // eslint-disable-line
+    class CustomizedRange extends React.Component {
+      // eslint-disable-line
       state = {
         value: [20, 40],
       };
-      onChange = (value) => {
+
+      onChange = value => {
         this.setState({
           value,
         });
-      }
+      };
+
       getSlider() {
         return this.slider;
       }
-      saveSlider = (slider) => {
+
+      saveSlider = slider => {
         this.slider = slider;
-      }
+      };
+
       render() {
-        return <Range ref={this.saveSlider} allowCross={false} value={this.state.value} pushable onChange={this.onChange} />;
+        return (
+          <Range
+            ref={this.saveSlider}
+            allowCross={false}
+            value={this.state.value}
+            pushable
+            onChange={this.onChange}
+          />
+        );
       }
     }
     const map = {};
@@ -255,7 +418,7 @@ describe('Range', () => {
       map[event] = cb;
     });
 
-    const mockRect = (wrapper) => {
+    const mockRect = wrapper => {
       wrapper.instance().getSlider().sliderRef.getBoundingClientRect = () => ({
         left: 0,
         width: 100,
@@ -270,41 +433,117 @@ describe('Range', () => {
 
     expect(wrapper.instance().getSlider().state.bounds).toEqual([20, 40]);
 
-    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 0, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
-    map.mousemove({ type: 'mousemove', pageX: 30, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
-    map.mouseup({ type: 'mouseup', pageX: 30, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
+    wrapper.find('.rc-slider').simulate('mouseDown', {
+      button: 0,
+      pageX: 0,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
+    map.mousemove({
+      type: 'mousemove',
+      pageX: 30,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
+    map.mouseup({
+      type: 'mouseup',
+      pageX: 30,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
 
     expect(wrapper.instance().getSlider().state.bounds).toEqual([30, 40]);
 
-    wrapper.find('.rc-slider').simulate('mouseDown', { button: 0, pageX: 0, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
-    map.mousemove({ type: 'mousemove', pageX: 50, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
-    map.mouseup({ type: 'mouseup', pageX: 50, pageY: 0, stopPropagation: () => {}, preventDefault: () => {} });
+    wrapper.find('.rc-slider').simulate('mouseDown', {
+      button: 0,
+      pageX: 0,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
+    map.mousemove({
+      type: 'mousemove',
+      pageX: 50,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
+    map.mouseup({
+      type: 'mouseup',
+      pageX: 50,
+      pageY: 0,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    });
     expect(wrapper.instance().getSlider().state.bounds).toEqual([39, 40]);
   });
 
   it('sets aria-label on the handles', () => {
     const wrapper = mount(<Range ariaLabelGroupForHandles={['Some Label', 'Some other Label']} />);
-    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-label')).toEqual('Some Label');
-    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-label')).toEqual('Some other Label');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-1')
+        .at(1)
+        .prop('aria-label'),
+    ).toEqual('Some Label');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-2')
+        .at(1)
+        .prop('aria-label'),
+    ).toEqual('Some other Label');
   });
 
   it('sets aria-labelledby on the handles', () => {
     const wrapper = mount(<Range ariaLabelledByGroupForHandles={['some_id', 'some_other_id']} />);
-    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-labelledby')).toEqual('some_id');
-    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-labelledby')).toEqual('some_other_id');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-1')
+        .at(1)
+        .prop('aria-labelledby'),
+    ).toEqual('some_id');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-2')
+        .at(1)
+        .prop('aria-labelledby'),
+    ).toEqual('some_other_id');
   });
 
   it('sets aria-valuetext on the handles', () => {
-    const wrapper = mount(<Range min={0} max={5} defaultValue={[1, 3]} ariaValueTextFormatterGroupForHandles={[(value) => `${value} of something`, (value) => `${value} of something else`]} />);
-    expect(wrapper.find('.rc-slider-handle-1').at(1).prop('aria-valuetext')).toEqual('1 of something');
-    expect(wrapper.find('.rc-slider-handle-2').at(1).prop('aria-valuetext')).toEqual('3 of something else');
+    const wrapper = mount(
+      <Range
+        min={0}
+        max={5}
+        defaultValue={[1, 3]}
+        ariaValueTextFormatterGroupForHandles={[
+          value => `${value} of something`,
+          value => `${value} of something else`,
+        ]}
+      />,
+    );
+    expect(
+      wrapper
+        .find('.rc-slider-handle-1')
+        .at(1)
+        .prop('aria-valuetext'),
+    ).toEqual('1 of something');
+    expect(
+      wrapper
+        .find('.rc-slider-handle-2')
+        .at(1)
+        .prop('aria-valuetext'),
+    ).toEqual('3 of something else');
   });
 
   // Corresponds to the issue described in https://github.com/react-component/slider/issues/690.
   it('should correctly display a dynamically decreased number of handles', () => {
     class RangeUnderTest extends React.Component {
       state = {
-        handles: [0, 25, 50, 75, 100]
+        handles: [0, 25, 50, 75, 100],
       };
 
       render() {
@@ -312,11 +551,11 @@ describe('Range', () => {
           <Range
             allowCross={false}
             marks={{
-              0: { label: "0", style: {} },
-              25: { label: "25", style: {} },
-              50: { label: "50", style: {} },
-              75: { label: "75", style: {} },
-              100: { label: "100", style: {} }
+              0: { label: '0', style: {} },
+              25: { label: '25', style: {} },
+              50: { label: '50', style: {} },
+              75: { label: '75', style: {} },
+              100: { label: '100', style: {} },
             }}
             step={null}
             value={this.state.handles}
@@ -329,14 +568,17 @@ describe('Range', () => {
     rangeUnderTest.setState({ handles: [0, 75, 100] });
 
     // Has the number of handles that we set.
-    expect(rangeUnderTest.find('div.rc-slider-handle')).toHaveLength(rangeUnderTest.state('handles').length);
+    expect(rangeUnderTest.find('div.rc-slider-handle')).toHaveLength(
+      rangeUnderTest.state('handles').length,
+    );
     // Handles have the values that we set.
     expect(
       rangeUnderTest
         .find('div.rc-slider-handle')
-        .everyWhere((element, index) =>
-          Number(element.prop('aria-valuenow')) === rangeUnderTest.state('handles')[index]
-        )
+        .everyWhere(
+          (element, index) =>
+            Number(element.prop('aria-valuenow')) === rangeUnderTest.state('handles')[index],
+        ),
     ).toEqual(true);
   });
 
@@ -352,7 +594,7 @@ describe('Range', () => {
       document.body.removeChild(container);
     });
 
-    const mockRect = (wrapper) => {
+    const mockRect = wrapper => {
       wrapper.instance().sliderRef.getBoundingClientRect = () => ({
         left: 10,
         width: 100,
@@ -361,10 +603,9 @@ describe('Range', () => {
 
     it('focus()', () => {
       const handleFocus = jest.fn();
-      const wrapper = mount(
-        <Range min={0} max={20} onFocus={handleFocus} />,
-        { attachTo: container }
-      );
+      const wrapper = mount(<Range min={0} max={20} onFocus={handleFocus} />, {
+        attachTo: container,
+      });
       mockRect(wrapper);
       wrapper.instance().focus();
       expect(handleFocus).toBeCalled();
@@ -372,10 +613,9 @@ describe('Range', () => {
 
     it('blur', () => {
       const handleBlur = jest.fn();
-      const wrapper = mount(
-        <Range min={0} max={20} onBlur={handleBlur} />,
-        { attachTo: container }
-      );
+      const wrapper = mount(<Range min={0} max={20} onBlur={handleBlur} />, {
+        attachTo: container,
+      });
       mockRect(wrapper);
       wrapper.instance().focus();
       wrapper.instance().blur();


### PR DESCRIPTION
This PR implements the changes suggested in #690 to fix how `Range` incorrectly handles the dynamic de/increase in the number of handles.