### PR TITLE
Fix type definition bug

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface GenericSliderProps {
   min?: number;
   max?: number;
-  step?: number;
+  step?: number | null;
   prefixCls?: string;
   vertical?: boolean;
   included?: boolean;


### PR DESCRIPTION
I'm getting this error.
```
node_modules/rc-slider/lib/Slider.d.ts:3:18 - error TS2430: Interface 'SliderProps' incorrectly extends interface 'GenericSliderProps'.
  Types of property 'step' are incompatible.
    Type 'number | null | undefined' is not assignable to type 'number | undefined'.
      Type 'null' is not assignable to type 'number | undefined'.

3 export interface SliderProps extends GenericSliderProps {
                   ~~~~~~~~~~~
```

This is breaking my build so it would be nice if you could release a new patch version after this PR. Thanks.