### PR TITLE
fix bug: slider cannot drag to max value

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,8 @@ export function isNotTouchEvent(e: React.TouchEvent) {
 export function getClosestPoint(val: number, { marks, step, min, max }) {
   const points = Object.keys(marks).map(parseFloat);
   if (step !== null) {
-    const maxSteps = Math.floor((max - min) / step);
+    const baseNum = 10 ** getPrecision(step);
+    const maxSteps = Math.floor((max * baseNum - min * baseNum) / (step * baseNum));
     const steps = Math.min((val - min) / step, maxSteps);
     const closestStep = Math.round(steps) * step + min;
     points.push(closestStep);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -9,7 +9,7 @@ describe('utils', () => {
         marks: { 0: 0, 30: 30, 60: 60 },
         step: null,
         min: 0,
-        max: 100
+        max: 100,
       };
 
       expect(utils.getClosestPoint(value, props)).toBe(30);
@@ -21,7 +21,7 @@ describe('utils', () => {
         marks: { 0: 0, 30: 30, 60: 60 },
         step: 3,
         min: 0,
-        max: 100
+        max: 100,
       };
 
       expect(utils.getClosestPoint(value, props)).toBe(39);
@@ -33,10 +33,39 @@ describe('utils', () => {
         marks: {},
         step: 6,
         min: 0,
-        max: 100
+        max: 100,
       };
 
       expect(utils.getClosestPoint(value, props)).toBe(96);
+    });
+
+    it('should return closest precision float value', () => {
+      expect(
+        utils.ensureValuePrecision(8151.23, {
+          marks: {},
+          step: 0.01,
+          min: 0.2,
+          max: 8151.23,
+        }),
+      ).toBe(8151.23);
+
+      expect(
+        utils.ensureValuePrecision(0.2, {
+          marks: {},
+          step: 0.01,
+          min: 0.2,
+          max: 8151.23,
+        }),
+      ).toBe(0.2);
+
+      expect(
+        utils.ensureValuePrecision(815.23, {
+          marks: {},
+          step: 0.01,
+          min: 0.2,
+          max: 8151.23,
+        }),
+      ).toBe(815.23);
     });
   });
 });


### PR DESCRIPTION
修复 getClosestPoint 函数由于浮点数计算精度问题导致的 bug [#27571](https://github.com/ant-design/ant-design/issues/27571) 