### PR TITLE
RangeProps allows number for `pushable`

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -39,7 +39,7 @@ export interface RangeProps extends GenericSliderProps {
   min?: number;
   max?: number;
   allowCross?: boolean;
-  pushable?: boolean;
+  pushable?: boolean | number;
   onChange?: (value: number[]) => void;
   onBeforeChange?: (value: number[]) => void;
   onAfterChange?: (value: number[]) => void;


### PR DESCRIPTION
The top-level `README` describes the `pushable` prop of `Range` as `boolean` or `number` (or `undefined`), but the type annotation in `Range.tsx` is `pushable?: boolean;`. When developing with `rc-slider` in Typescript, using for example `pushable={5}` causes a type error, and the only way around this is `pushable={(5 as unknown) as undefined}` which then produces the expected behaviour. This type annotation appears to be incorrect and would be great to have it updated.