### PR TITLE
change ariaValueTextFormatter type

### DIFF
--- a/src/Handle.tsx
+++ b/src/Handle.tsx
@@ -16,7 +16,7 @@ export interface HandleProps {
   tabIndex?: number;
   ariaLabel?: string;
   ariaLabelledBy?: string;
-  ariaValueTextFormatter?: (val: number) => string;
+  ariaValueTextFormatter?: string;
   onMouseEnter?: React.MouseEventHandler;
   onMouseLeave?: React.MouseEventHandler;
 }


### PR DESCRIPTION
TypeScript warns about type incapability when I use a custom Handle