### PR TITLE
Allow Range prop `step` to be null in Typescript

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -3,8 +3,8 @@ import classNames from 'classnames';
 import Track from './common/Track';
 import createSlider from './common/createSlider';
 import * as utils from './utils';
-import { SliderProps } from './Slider';
-import { GenericSliderProps, GenericSliderState } from './interface';
+import type { SliderProps } from './Slider';
+import type { GenericSliderProps, GenericSliderState } from './interface';
 
 const trimAlignValue = ({
   value,
@@ -46,7 +46,7 @@ export interface RangeProps extends GenericSliderProps {
   reverse?: boolean;
   vertical?: boolean;
   marks?: Record<number, React.ReactNode | { style?: React.CSSProperties; label?: string }>;
-  step?: number;
+  step?: number | null;
   threshold?: number;
   prefixCls?: string;
   included?: boolean;
@@ -182,8 +182,8 @@ class Range extends React.Component<RangeProps, RangeState> {
       return;
     }
     const currentValue = value || prevState.bounds;
-    if (currentValue.some(v => utils.isValueOutOfRange(v, this.props))) {
-      const newValues = currentValue.map(v => utils.ensureValueInRange(v, this.props));
+    if (currentValue.some((v) => utils.isValueOutOfRange(v, this.props))) {
+      const newValues = currentValue.map((v) => utils.ensureValueInRange(v, this.props));
       onChange(newValues);
     }
   }
@@ -196,7 +196,7 @@ class Range extends React.Component<RangeProps, RangeState> {
     } else {
       const controlledState = {};
 
-      ['handle', 'recent'].forEach(item => {
+      ['handle', 'recent'].forEach((item) => {
         if (state[item] !== undefined) {
           controlledState[item] = state[item];
         }
@@ -277,10 +277,10 @@ class Range extends React.Component<RangeProps, RangeState> {
       const max = maxValue - Math.max(...startBounds);
       const min = minValue - Math.min(...startBounds);
       const ratio = Math.min(Math.max(pos / (this.getSliderLength() / 100), min), max);
-      const nextBounds = startBounds.map(v =>
+      const nextBounds = startBounds.map((v) =>
         Math.floor(Math.max(Math.min(v + ratio, maxValue), minValue)),
       );
-      if (state.bounds.map((c, i) => c === nextBounds[i]).some(c => !c)) {
+      if (state.bounds.map((c, i) => c === nextBounds[i]).some((c) => !c)) {
         this.onChange({
           bounds: nextBounds,
         });
@@ -504,7 +504,7 @@ class Range extends React.Component<RangeProps, RangeState> {
       ariaValueTextFormatterGroupForHandles,
     } = this.props;
 
-    const offsets = bounds.map(v => this.calcOffset(v));
+    const offsets = bounds.map((v) => this.calcOffset(v));
 
     const handleClassName = `${prefixCls}-handle`;
     const handles = bounds.map((v, i) => {
@@ -531,7 +531,7 @@ class Range extends React.Component<RangeProps, RangeState> {
         reverse,
         disabled,
         style: handleStyle[i],
-        ref: h => this.saveHandle(i, h),
+        ref: (h) => this.saveHandle(i, h),
         ariaLabel: ariaLabelGroupForHandles[i],
         ariaLabelledBy: ariaLabelledByGroupForHandles[i],
         ariaValueTextFormatter: ariaValueTextFormatterGroupForHandles[i],


### PR DESCRIPTION
This is the same like #691 where it was fixed for `Slider` but `Range` seems to have been forgotten. Fixes #739 #652 #574