### PR TITLE
Extended GenericSliderProps to allow for onClick events

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-export interface GenericSliderProps {
+export interface GenericSliderProps extends React.HTMLAttributes<HTMLDivElement> {
   min?: number;
   max?: number;
   step?: number | null;


### PR DESCRIPTION
Extended GenericSliderProps with React.HTMLAttributes<HTMLDivElement> so that onClick events can be added