### PR TITLE
adds key to handle component

### DIFF
--- a/src/Range.tsx
+++ b/src/Range.tsx
@@ -495,7 +495,7 @@ class Range extends React.Component<RangeProps, RangeState> {
       min,
       max,
       reverse,
-      handle: handleGenerator,
+      handle: Handle,
       trackStyle,
       handleStyle,
       tabIndex,
@@ -513,7 +513,8 @@ class Range extends React.Component<RangeProps, RangeState> {
         mergedTabIndex = null;
       }
       const dragging = handle === i;
-      return handleGenerator({
+
+      const handleProps = {
         className: classNames({
           [handleClassName]: true,
           [`${handleClassName}-${i + 1}`]: true,
@@ -535,7 +536,9 @@ class Range extends React.Component<RangeProps, RangeState> {
         ariaLabel: ariaLabelGroupForHandles[i],
         ariaLabelledBy: ariaLabelledByGroupForHandles[i],
         ariaValueTextFormatter: ariaValueTextFormatterGroupForHandles[i],
-      });
+      };
+
+      return <Handle key={ariaLabelGroupForHandles[i] || i} {...handleProps} />;
     });
 
     const tracks = bounds.slice(0, -1).map((_, index) => {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import warning from 'rc-util/lib/warning';
-import Track from './common/Track';
+import React from 'react';
 import createSlider from './common/createSlider';
-import * as utils from './utils';
+import Track from './common/Track';
 import type { GenericSliderProps, GenericSliderState } from './interface';
+import * as utils from './utils';
 
 export interface SliderProps extends GenericSliderProps {
   value?: number;
@@ -229,11 +229,11 @@ class Slider extends React.Component<SliderProps, SliderState> {
       max,
       startPoint,
       reverse,
-      handle: handleGenerator,
+      handle: Handle,
     } = this.props;
     const { value, dragging } = this.state;
     const offset = this.calcOffset(value);
-    const handle = handleGenerator({
+    const handleProps = {
       className: `${prefixCls}-handle`,
       prefixCls,
       vertical,
@@ -251,7 +251,8 @@ class Slider extends React.Component<SliderProps, SliderState> {
       ariaValueTextFormatter: ariaValueTextFormatterForHandle,
       style: handleStyle[0] || handleStyle,
       ref: (h) => this.saveHandle(0, h),
-    });
+    };
+    const handle = <Handle {...handleProps} />;
 
     const trackOffset = startPoint !== undefined ? this.calcOffset(startPoint) : 0;
     const mergedTrackStyle = trackStyle[0] || trackStyle;

--- a/src/common/createSlider.tsx
+++ b/src/common/createSlider.tsx
@@ -1,13 +1,32 @@
-import React from 'react';
-import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import classNames from 'classnames';
+import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import warning from 'rc-util/lib/warning';
-import Steps from './Steps';
-import Marks from './Marks';
+import React from 'react';
 import type { HandleProps } from '../Handle';
 import Handle from '../Handle';
+import type { GenericSlider, GenericSliderProps, GenericSliderState } from '../interface';
 import * as utils from '../utils';
-import type { GenericSliderProps, GenericSliderState, GenericSlider } from '../interface';
+import Marks from './Marks';
+import Steps from './Steps';
+
+interface RenderHandleProps extends HandleProps {
+  index: number;
+  dragging: boolean;
+}
+
+const RenderHandle: React.ForwardRefRenderFunction<Handle, RenderHandleProps> = (
+  props: RenderHandleProps,
+  ref,
+) => {
+  const { index, ...restProps } = props;
+  delete restProps.dragging;
+  if (restProps.value === null) {
+    return null;
+  }
+
+  return <Handle ref={ref} {...restProps} key={index} />;
+};
+const HandleComponent = React.forwardRef(RenderHandle);
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -29,15 +48,7 @@ export default function createSlider<
       max: 100,
       step: 1,
       marks: {},
-      handle(props: HandleProps & { index: number; dragging: boolean }) {
-        const { index, ...restProps } = props;
-        delete restProps.dragging;
-        if (restProps.value === null) {
-          return null;
-        }
-
-        return <Handle {...restProps} key={index} />;
-      },
+      handle: HandleComponent,
       onBeforeChange: noop,
       onChange: noop,
       onAfterChange: noop,


### PR DESCRIPTION
Reported in #358 

The issue was supposed to be fixed, nevertheless 7 people, including myself have witnessed the problem in the newest version (`9.7.2`).

With the following adjustment the issue was amended. Additionally the type signature of `Slider['handle']`:
```ts
handle?: (props: {
    className: string;
    prefixCls?: string;
    vertical?: boolean;
    offset: number;
    value: number;
    dragging?: boolean;
    disabled?: boolean;
    min?: number;
    max?: number;
    reverse?: boolean;
    index: number;
    tabIndex?: number;
    ariaLabel: string;
    ariaLabelledBy: string;
    ariaValueTextFormatter: string;
    style?: React.CSSProperties;
    ref?: React.Ref<any>;
  }) => React.ReactElement;
```

Already closely matches `React.FC`:
```ts
interface FunctionComponent<P = {}> {
        (props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
        propTypes?: WeakValidationMap<P>;
        contextTypes?: ValidationMap<any>;
        defaultProps?: Partial<P>;
        displayName?: string;
    }
```

With the accent on `(props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;`. Hence there is no downside to instantiating it like a component.

Furthermore the presence of the `key` is supposed to save a number DOM updates, as `React` is able to match the instances by reference during reconciliation.