### PR TITLE
ensure onBeforeChange is called when clicking the rail

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -298,6 +298,7 @@ const Slider = React.forwardRef((props: SliderProps, ref: React.Ref<SliderRef>) 
         cloneNextValues.push(newValue);
       }
 
+      onBeforeChange?.(cloneNextValues);
       triggerChange(cloneNextValues);
       onAfterChange?.(getTriggerValue(cloneNextValues));
     }

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -298,7 +298,7 @@ const Slider = React.forwardRef((props: SliderProps, ref: React.Ref<SliderRef>) 
         cloneNextValues.push(newValue);
       }
 
-      onBeforeChange?.(cloneNextValues);
+      onBeforeChange?.(getTriggerValue(cloneNextValues));
       triggerChange(cloneNextValues);
       onAfterChange?.(getTriggerValue(cloneNextValues));
     }

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -489,13 +489,23 @@ describe('Slider', () => {
 
   describe('click slider to change value', () => {
     it('ltr', () => {
+      const onBeforeChange = jest.fn();
       const onChange = jest.fn();
-      const { container } = render(<Slider onChange={onChange} />);
+      const onAfterChange = jest.fn();
+      const { container } = render(
+        <Slider
+          onBeforeChange={onBeforeChange}
+          onChange={onChange}
+          onAfterChange={onAfterChange}
+        />,
+      );
       fireEvent.mouseDown(container.querySelector('.rc-slider'), {
         clientX: 20,
       });
 
+      expect(onBeforeChange).toHaveBeenCalledWith(20);
       expect(onChange).toHaveBeenCalledWith(20);
+      expect(onAfterChange).toHaveBeenCalledWith(20);
     });
 
     it('rtl', () => {

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -489,23 +489,13 @@ describe('Slider', () => {
 
   describe('click slider to change value', () => {
     it('ltr', () => {
-      const onBeforeChange = jest.fn();
       const onChange = jest.fn();
-      const onAfterChange = jest.fn();
-      const { container } = render(
-        <Slider
-          onBeforeChange={onBeforeChange}
-          onChange={onChange}
-          onAfterChange={onAfterChange}
-        />,
-      );
+      const { container } = render(<Slider onChange={onChange} />);
       fireEvent.mouseDown(container.querySelector('.rc-slider'), {
         clientX: 20,
       });
 
-      expect(onBeforeChange).toHaveBeenCalledWith(20);
       expect(onChange).toHaveBeenCalledWith(20);
-      expect(onAfterChange).toHaveBeenCalledWith(20);
     });
 
     it('rtl', () => {
@@ -546,6 +536,26 @@ describe('Slider', () => {
       });
 
       expect(onChange).toHaveBeenCalledWith([20, 20]);
+    });
+
+    it('should call onBeforeChange, onChange, and onAfterChange', () => {
+      const onBeforeChange = jest.fn();
+      const onChange = jest.fn();
+      const onAfterChange = jest.fn();
+      const { container } = render(
+        <Slider
+          onBeforeChange={onBeforeChange}
+          onChange={onChange}
+          onAfterChange={onAfterChange}
+        />,
+      );
+      fireEvent.mouseDown(container.querySelector('.rc-slider'), {
+        clientX: 20,
+      });
+
+      expect(onBeforeChange).toHaveBeenCalledWith(20);
+      expect(onChange).toHaveBeenCalledWith(20);
+      expect(onAfterChange).toHaveBeenCalledWith(20);
     });
   });
 


### PR DESCRIPTION
In version 10.0.0-alpha.5, when you click the rail, the following events are fired: `onChange`, `onAfterChange`. This PR ensures that `onBeforeChange` will be fired as well.

Background: there has historically been some bugginess around which events are fired when clicking on the rail. In version 8.6.1, we correctly fired all three: `onBeforeChange`, `onChange`, `onAfterChange`. 

In version 9.7.5, we fired too many events when clicking on the rail: `onBeforeChange`, `onChange`, `onBeforeChange`, `onAfterChange`.

See this issue for more people that have been affected by these event firing inconsistencies: https://github.com/react-component/slider/issues/492