### PR TITLE
Fix: onAfterChange give a number instead of an array of number

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -299,7 +299,7 @@ const Slider = React.forwardRef((props: SliderProps, ref: React.Ref<SliderRef>) 
       }
 
       triggerChange(cloneNextValues);
-      onAfterChange?.(cloneNextValues);
+      onAfterChange?.(getTriggerValue(cloneNextValues));
     }
   };
 


### PR DESCRIPTION
When you click on the rail and the range props is set to false, the onAfterChange give back the value of the slider as a number instead of an array of number.

In version 9.7.5, the onAfterChange function worked like that.

Thanks for reading