### PR TITLE
Allow callback for "dotStyle" and "activeDotStyle" props

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The following APIs are shared by Slider and Range.
 | handleStyle | Array[Object] \| Object | `[{}]` | The style used for handle. (`both for slider(`Object`) and range(`Array of Object`), the array will be used for multi handle following element order`) |
 | trackStyle | Array[Object] \| Object | `[{}]` | The style used for track. (`both for slider(`Object`) and range(`Array of Object`), the array will be used for multi track following element order`)|
 | railStyle | Object | `{}` | The style used for the track base color.  |
-| dotStyle | Object | `{}` | The style used for the dots. |
-| activeDotStyle | Object | `{}` | The style used for the active dots. |
+| dotStyle | Object or (dotValue) => Object | `{}` | The style used for the dots. |
+| activeDotStyle | Object or (dotValue) => Object | `{}` | The style used for the active dots. |
 
 ### Slider
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -72,8 +72,8 @@ export interface SliderProps<ValueType = number | number[]> {
   trackStyle?: React.CSSProperties | React.CSSProperties[];
   handleStyle?: React.CSSProperties | React.CSSProperties[];
   railStyle?: React.CSSProperties;
-  dotStyle?: React.CSSProperties;
-  activeDotStyle?: React.CSSProperties;
+  dotStyle?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
+  activeDotStyle?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
 
   // Decorations
   marks?: Record<string | number, React.ReactNode | MarkObj>;

--- a/src/Steps/Dot.tsx
+++ b/src/Steps/Dot.tsx
@@ -6,8 +6,8 @@ import SliderContext from '../context';
 export interface DotProps {
   prefixCls: string;
   value: number;
-  style?: React.CSSProperties;
-  activeStyle?: React.CSSProperties;
+  style?: React.CSSProperties | ((number) => React.CSSProperties);
+  activeStyle?: React.CSSProperties | ((number) => React.CSSProperties);
 }
 
 export default function Dot(props: DotProps) {

--- a/src/Steps/Dot.tsx
+++ b/src/Steps/Dot.tsx
@@ -6,8 +6,8 @@ import SliderContext from '../context';
 export interface DotProps {
   prefixCls: string;
   value: number;
-  style?: React.CSSProperties | ((number) => React.CSSProperties);
-  activeStyle?: React.CSSProperties | ((number) => React.CSSProperties);
+  style?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
+  activeStyle?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
 }
 
 export default function Dot(props: DotProps) {

--- a/src/Steps/Dot.tsx
+++ b/src/Steps/Dot.tsx
@@ -21,13 +21,13 @@ export default function Dot(props: DotProps) {
   // ============================ Offset ============================
   let mergedStyle = {
     ...getDirectionStyle(direction, value, min, max),
-    ...style,
+    ...(typeof style === 'function' ? style(value) : style),
   };
 
   if (active) {
     mergedStyle = {
       ...mergedStyle,
-      ...activeStyle,
+      ...(typeof activeStyle === 'function' ? activeStyle(value) : activeStyle),
     };
   }
 

--- a/src/Steps/index.tsx
+++ b/src/Steps/index.tsx
@@ -7,8 +7,8 @@ export interface StepsProps {
   prefixCls: string;
   marks: InternalMarkObj[];
   dots?: boolean;
-  style?: React.CSSProperties;
-  activeStyle?: React.CSSProperties;
+  style?: React.CSSProperties | ((number) => React.CSSProperties);
+  activeStyle?: React.CSSProperties | ((number) => React.CSSProperties);
 }
 
 export default function Steps(props: StepsProps) {

--- a/src/Steps/index.tsx
+++ b/src/Steps/index.tsx
@@ -7,8 +7,8 @@ export interface StepsProps {
   prefixCls: string;
   marks: InternalMarkObj[];
   dots?: boolean;
-  style?: React.CSSProperties | ((number) => React.CSSProperties);
-  activeStyle?: React.CSSProperties | ((number) => React.CSSProperties);
+  style?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
+  activeStyle?: React.CSSProperties | ((dotValue: number) => React.CSSProperties);
 }
 
 export default function Steps(props: StepsProps) {


### PR DESCRIPTION
I have to use rc-slider to make a range selector, where the active range has a horizontal color gradient. I can style the trackline with pure CSS, but not the step dots. I even went to great extents with CSS by adding some creative attribute selectors based on the `style="left: ..."` values, which was enough to have the correct dot colors when the full range is selected. But when the range is set to a narrower state, the gradient changes too, and the dots can't adapt to that. I can only solve this with a callback where I can set the style based on the dot position and the slider value. This is what this PR is about.