### PR TITLE
fix: dot wrong event of pointer https://github.com/ant-design/ant-design/issues/40288

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -117,7 +117,6 @@
     width: 100%;
     height: 4px;
     background: transparent;
-    pointer-events: none;
   }
 
   &-dot {

--- a/assets/index.less
+++ b/assets/index.less
@@ -124,7 +124,6 @@
     bottom: -2px;
     width: 8px;
     height: 8px;
-    // margin-left: -4px;
     vertical-align: middle;
     background-color: #fff;
     border: 2px solid #e9e9e9;
@@ -196,13 +195,6 @@
 
     &-dot {
       margin-left: -2px;
-      // margin-bottom: -4px;
-      // &:first-child {
-      //   margin-bottom: -4px;
-      // }
-      // &:last-child {
-      //   margin-bottom: -4px;
-      // }
     }
   }
 }


### PR DESCRIPTION
让 silder 本身的标记点可以触发相关的事件不会出穿透点击事件，从而修复小的标记点实际触发范围的异常

issue: https://github.com/ant-design/ant-design/issues/40288
