### PR TITLE
Add custom element as handle

### DIFF
--- a/docs/examples/slider.tsx
+++ b/docs/examples/slider.tsx
@@ -72,6 +72,20 @@ const NullableRangeSlider = () => {
   );
 };
 
+const CustomHandle = () => {
+  return (
+    <div style={{
+      width: 0,
+      height: 0,
+      borderLeft: '8px solid transparent',
+      borderRight: '8px solid transparent',
+      borderTop: '16px solid red',
+      marginTop: -10,
+      marginLeft: -4,
+    }}/>
+  )
+};
+
 class CustomizedSlider extends React.Component<any, any> {
   constructor(props) {
     super(props);
@@ -191,6 +205,18 @@ export default () => (
     <div style={style}>
       <p>Basic Slider, `startPoint=50`</p>
       <Slider onChange={log} startPoint={50} />
+    </div>
+    <div style={style}>
+      <p>Basic Slider with custom handle</p>
+      <Slider
+        onChange={log}
+        defaultValue={30}
+        styles={{
+          handle: {
+            opacity: 1,
+          }
+        }}
+        customHandle={<CustomHandle />}/>
     </div>
     <div style={style}>
       <p>Slider reverse</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-slider",
-  "version": "10.5.1",
+  "version": "10.5.0",
   "description": "Slider UI component for React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-slider",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "description": "Slider UI component for React",
   "keywords": [
     "react",

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -24,6 +24,7 @@ export interface HandleProps {
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   render?: (origin: React.ReactElement<HandleProps>, props: RenderProps) => React.ReactElement;
   onChangeComplete?: () => void;
+  customHandle?: React.JSX.Element;
 }
 
 const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
@@ -37,6 +38,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     dragging,
     onOffsetChange,
     onChangeComplete,
+    customHandle,
     ...restProps
   } = props;
   const {
@@ -162,7 +164,9 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
       aria-valuetext={getIndex(ariaValueTextFormatterForHandle, valueIndex)?.(value)}
       aria-orientation={direction === 'ltr' || direction === 'rtl' ? 'horizontal' : 'vertical'}
       {...restProps}
-    />
+    >
+      {customHandle}
+    </div>
   );
 
   // Customize

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -148,6 +148,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
         ...positionStyle,
         ...style,
         ...styles.handle,
+        ...(customHandle ? { visibility: 'hidden' } : {}),
       }}
       onMouseDown={onInternalStartMove}
       onTouchStart={onInternalStartMove}
@@ -165,7 +166,11 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
       aria-orientation={direction === 'ltr' || direction === 'rtl' ? 'horizontal' : 'vertical'}
       {...restProps}
     >
-      {customHandle}
+      {customHandle && (
+        <div style={{ visibility: 'visible' }}>
+          {customHandle}
+        </div>
+      )}
     </div>
   );
 

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -24,7 +24,7 @@ export interface HandleProps {
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   render?: (origin: React.ReactElement<HandleProps>, props: RenderProps) => React.ReactElement;
   onChangeComplete?: () => void;
-  customHandle?: React.JSX.Element;
+  customHandle?: JSX.Element;
 }
 
 const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -167,7 +167,9 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
       {...restProps}
     >
       {customHandle && (
-        <div style={{ visibility: 'visible' }}>
+        <div
+        className={cls(`${prefixCls}-custom-handle`)}
+        style={{ visibility: 'visible' }}>
           {customHandle}
         </div>
       )}

--- a/src/Handles/index.tsx
+++ b/src/Handles/index.tsx
@@ -15,6 +15,7 @@ export interface HandlesProps {
   handleRender?: HandleProps['render'];
   draggingIndex: number;
   onChangeComplete?: () => void;
+  customHandle?: React.JSX.Element;
 }
 
 export interface HandlesRef {
@@ -30,6 +31,7 @@ const Handles = React.forwardRef<HandlesRef, HandlesProps>((props, ref) => {
     values,
     handleRender,
     draggingIndex,
+    customHandle,
     ...restProps
   } = props;
   const handlesRef = React.useRef<Record<number, HTMLDivElement>>({});
@@ -60,6 +62,7 @@ const Handles = React.forwardRef<HandlesRef, HandlesProps>((props, ref) => {
           onStartMove={onStartMove}
           onOffsetChange={onOffsetChange}
           render={handleRender}
+          customHandle={customHandle}
           {...restProps}
         />
       ))}

--- a/src/Handles/index.tsx
+++ b/src/Handles/index.tsx
@@ -15,7 +15,7 @@ export interface HandlesProps {
   handleRender?: HandleProps['render'];
   draggingIndex: number;
   onChangeComplete?: () => void;
-  customHandle?: React.JSX.Element;
+  customHandle?: JSX.Element;
 }
 
 export interface HandlesRef {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -93,6 +93,7 @@ export interface SliderProps<ValueType = number | number[]> {
 
   // Components
   handleRender?: HandlesProps['handleRender'];
+  customHandle?: React.JSX.Element;
 
   // Accessibility
   tabIndex?: number | number[];
@@ -158,6 +159,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
     // Components
     handleRender,
+    customHandle,
 
     // Accessibility
     tabIndex = 0,
@@ -544,6 +546,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
           onBlur={onBlur}
           handleRender={handleRender}
           onChangeComplete={finishChange}
+          customHandle={customHandle}
         />
 
         <Marks prefixCls={prefixCls} marks={markList} onClick={changeToCloseValue} />

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -93,7 +93,7 @@ export interface SliderProps<ValueType = number | number[]> {
 
   // Components
   handleRender?: HandlesProps['handleRender'];
-  customHandle?: React.JSX.Element;
+  customHandle?: JSX.Element;
 
   // Accessibility
   tabIndex?: number | number[];

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -654,4 +654,17 @@ describe('Slider', () => {
     const { asFragment } = render(<Slider included={false} />);
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
+  it('should render custom handle', () => {
+    const { container } = render(<Slider customHandle={
+      <div style={{
+        width: '20px',
+        height: '20px',
+        background: 'red',
+        cursor: 'pointer',
+      }}/>
+    } />);
+    expect(container.querySelector('.rc-slider-handle').style.visibility).toBe('hidden');
+    expect(container.querySelector('.rc-slider-custom-handle').style.visibility).toBe('visible');
+  });
 });


### PR DESCRIPTION
Added customHandle to Slider props allowing the user to pass in a custom element which will be displayed as the handle.

Aims to solve needing to downgrade to V9 as mentioned here: https://github.com/react-component/slider/issues/736#issuecomment-1563991591

