### PR TITLE
chore(deps): increase rc-util minimum to 5.36 due to usage of useEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
-    "rc-util": "^5.27.0"
+    "rc-util": "^5.36.0"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.2",


### PR DESCRIPTION
I noticed some CI was failing this morning, complaining about an unavailable import. 

It seems that [`src/hooks/useDrag.ts`](https://github.com/react-component/slider/blob/master/src/hooks/useDrag.ts) has started using `useEvent` from `rc-util` which has only become available from version 5.36, so the minimum version in `package.json` has to be increased.

Let me know if there's anything else I should do 😀