### PR TITLE
fix: When touch the slider while touching another area, the slider will move with the first touch

### DIFF
--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -8,7 +8,7 @@ import type { OffsetValues } from './useOffset';
 const REMOVE_DIST = 130;
 
 function getPosition(e: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent) {
-  const obj = 'touches' in e ? e.touches[0] : e;
+  const obj = 'targetTouches' in e ? e.targetTouches[0] : e;
 
   return { pageX: obj.pageX, pageY: obj.pageY };
 }

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -40,6 +40,7 @@ function useDrag(
 
   const mouseMoveEventRef = React.useRef<(event: MouseEvent) => void>(null);
   const mouseUpEventRef = React.useRef<(event: MouseEvent) => void>(null);
+  const touchEventTargetRef = React.useRef<EventTarget>(null);
 
   const { onDragStart, onDragChange } = React.useContext(UnstableContext);
 
@@ -54,8 +55,10 @@ function useDrag(
     () => () => {
       document.removeEventListener('mousemove', mouseMoveEventRef.current);
       document.removeEventListener('mouseup', mouseUpEventRef.current);
-      document.removeEventListener('touchmove', mouseMoveEventRef.current);
-      document.removeEventListener('touchend', mouseUpEventRef.current);
+      if (touchEventTargetRef.current) {
+        touchEventTargetRef.current.removeEventListener('touchmove', mouseMoveEventRef.current);
+        touchEventTargetRef.current.removeEventListener('touchend', mouseUpEventRef.current);
+      }
     },
     [],
   );
@@ -193,10 +196,11 @@ function useDrag(
 
       document.removeEventListener('mouseup', onMouseUp);
       document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('touchend', onMouseUp);
-      document.removeEventListener('touchmove', onMouseMove);
+      event.currentTarget.removeEventListener('touchend', onMouseUp);
+      event.currentTarget.removeEventListener('touchmove', onMouseMove);
       mouseMoveEventRef.current = null;
       mouseUpEventRef.current = null;
+      touchEventTargetRef.current = null;
 
       finishChange(deleteMark);
 
@@ -206,10 +210,11 @@ function useDrag(
 
     document.addEventListener('mouseup', onMouseUp);
     document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('touchend', onMouseUp);
-    document.addEventListener('touchmove', onMouseMove);
+    e.currentTarget.addEventListener('touchend', onMouseUp);
+    e.currentTarget.addEventListener('touchmove', onMouseMove);
     mouseMoveEventRef.current = onMouseMove;
     mouseUpEventRef.current = onMouseUp;
+    touchEventTargetRef.current = e.currentTarget;
   };
 
   // Only return cache value when it mapping with rawValues

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -196,8 +196,10 @@ function useDrag(
 
       document.removeEventListener('mouseup', onMouseUp);
       document.removeEventListener('mousemove', onMouseMove);
-      event.currentTarget.removeEventListener('touchend', onMouseUp);
-      event.currentTarget.removeEventListener('touchmove', onMouseMove);
+      if (touchEventTargetRef.current) {
+        touchEventTargetRef.current.removeEventListener('touchmove', mouseMoveEventRef.current);
+        touchEventTargetRef.current.removeEventListener('touchend', mouseUpEventRef.current);
+      }
       mouseMoveEventRef.current = null;
       mouseUpEventRef.current = null;
       touchEventTargetRef.current = null;

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -82,18 +82,16 @@ describe('Range', () => {
       touches: [{}],
       targetTouches: [{}],
     });
-    (touchStart as any).touches[0].pageX = start;
     (touchStart as any).targetTouches[0].pageX = start;
     fireEvent(container.getElementsByClassName(element)[0], touchStart);
 
     // Drag
-    const touchMove = createEvent.touchMove(document, {
+    const touchMove = createEvent.touchMove(container.getElementsByClassName(element)[0], {
       touches: [{}],
       targetTouches: [{}],
     });
-    (touchMove as any).touches[0].pageX = end;
     (touchMove as any).targetTouches[0].pageX = end;
-    fireEvent(document, touchMove);
+    fireEvent(container.getElementsByClassName(element)[0], touchMove);
   }
 
   it('should render Range with correct DOM structure', () => {

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -80,15 +80,19 @@ describe('Range', () => {
   ) {
     const touchStart = createEvent.touchStart(container.getElementsByClassName(element)[0], {
       touches: [{}],
+      targetTouches: [{}],
     });
     (touchStart as any).touches[0].pageX = start;
+    (touchStart as any).targetTouches[0].pageX = start;
     fireEvent(container.getElementsByClassName(element)[0], touchStart);
 
     // Drag
     const touchMove = createEvent.touchMove(document, {
       touches: [{}],
+      targetTouches: [{}],
     });
     (touchMove as any).touches[0].pageX = end;
+    (touchMove as any).targetTouches[0].pageX = end;
     fireEvent(document, touchMove);
   }
 


### PR DESCRIPTION
- fix #1036

Changes
- Since [TouchEvent.touches](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches) includes touches on areas other than the slider, I changed to use [targetTouches](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/targetTouches).
- Because if you start touching on the slider, touch events will be generated even if you drag outside the slider, I changed the target for registering the event listener to the slider (i.e., [Event.currentTarget](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 改进了触摸事件的处理，增强了拖放功能的准确性和可靠性，特别是在触摸设备上。
- **测试**
	- 更新了触摸交互的事件模拟，确保测试用例准确反映触摸事件的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->