### PR TITLE
fix: tipFormatter should not crash with undefined value

### DIFF
--- a/src/Tracks/index.tsx
+++ b/src/Tracks/index.tsx
@@ -47,12 +47,12 @@ const Tracks: React.FC<TrackProps> = (props) => {
 
   // ========================== Render ==========================
   const tracksNode =
-    classNames.tracks || styles.tracks ? (
+      trackList?.length && (classNames.tracks || styles.tracks) ? (
       <Track
         index={null}
         prefixCls={prefixCls}
-        start={trackList[0]?.start}
-        end={trackList[trackList?.length - 1]?.end}
+        start={trackList[0].start}
+        end={trackList[trackList.length - 1].end}
         replaceCls={cls(classNames.tracks, `${prefixCls}-tracks`)}
         style={styles.tracks}
       />

--- a/src/Tracks/index.tsx
+++ b/src/Tracks/index.tsx
@@ -51,8 +51,8 @@ const Tracks: React.FC<TrackProps> = (props) => {
       <Track
         index={null}
         prefixCls={prefixCls}
-        start={trackList[0].start}
-        end={trackList[trackList.length - 1].end}
+        start={trackList[0]?.start}
+        end={trackList[trackList?.length - 1]?.end}
         replaceCls={cls(classNames.tracks, `${prefixCls}-tracks`)}
         style={styles.tracks}
       />

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -662,4 +662,9 @@ describe('Slider', () => {
     const { asFragment } = render(<Slider included={false} />);
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+  it('tipFormatter should not crash with undefined value', () => {
+    [undefined, null].forEach((value) => {
+      render(<Slider value={value} tooltip={{ open: true }} styles={{ tracks: {} }}/>);
+    });
+  });
 });

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -662,6 +662,7 @@ describe('Slider', () => {
     const { asFragment } = render(<Slider included={false} />);
     expect(asFragment().firstChild).toMatchSnapshot();
   });
+
   it('tipFormatter should not crash with undefined value', () => {
     [undefined, null].forEach((value) => {
       render(<Slider value={value} tooltip={{ open: true }} styles={{ tracks: {} }}/>);


### PR DESCRIPTION
当使用 classNames.tracks || styles.tracks 的时候 undefined和null 的单测就会报错。


![image](https://github.com/user-attachments/assets/ad730c62-e81e-4ef3-97a8-a3df2eb505de)


![image](https://github.com/user-attachments/assets/efee4d31-ad6d-4bea-959d-c868265513cc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
	- 在 `Tracks` 组件中添加了可选链接，提高了代码的健壮性，防止在空列表或未定义的情况下出现错误。

- **测试**
	- 为 `Slider` 组件添加了新的测试用例，确保在处理未定义或空值时不会崩溃。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->