### PR TITLE
fix: onDelete is not a function

### DIFF
--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -22,7 +22,7 @@ export interface HandleProps
   dragging: boolean;
   draggingDelete: boolean;
   onStartMove: OnStartMove;
-  onDelete: (index: number) => void;
+  onDelete?: (index: number) => void;
   onOffsetChange: (value: number | 'min' | 'max', valueIndex: number) => void;
   onFocus: (e: React.FocusEvent<HTMLDivElement>, index: number) => void;
   onMouseEnter: (e: React.MouseEvent<HTMLDivElement>, index: number) => void;

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -127,7 +127,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
 
         case KeyCode.BACKSPACE:
         case KeyCode.DELETE:
-          onDelete(valueIndex);
+          onDelete?.(valueIndex);
           break;
       }
 

--- a/src/Handles/index.tsx
+++ b/src/Handles/index.tsx
@@ -13,7 +13,7 @@ export interface HandlesProps {
   onOffsetChange: (value: number | 'min' | 'max', valueIndex: number) => void;
   onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onDelete: (index: number) => void;
+  onDelete?: (index: number) => void;
   handleRender?: HandleProps['render'];
   /**
    * When config `activeHandleRender`,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/79fac4c1-483e-4344-b6d0-537a426fede3)

选中 Slider 后按下删除键会调用 onDelete，没有判空导致报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- 修正了删除操作时可能引发错误的问题，提升了整体的稳定性和用户体验。
- **新特性**
	- 允许在使用 `Handle` 组件时省略 `onDelete` 函数，提高了组件的灵活性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->