### PR TITLE
feat: support per-handle disabled for Range slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,12 @@ The following APIs are shared by Slider and Range.
 | handle | (props) => React.ReactNode | | A handle generator which could be used to customized handle. |
 | included | boolean | `true` | If the value is `true`, it means a continuous value interval, otherwise, it is a independent value. |
 | reverse | boolean | `false` | If the value is `true`, it means the component is rendered reverse. |
-| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. This prop can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. |
+| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. This prop can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. When disabled is an array with any `true` value, `editable` mode will be disabled. |
 | keyboard | boolean | `true` | Support using keyboard to move handlers. |
 | dots | boolean | `false` | When the `step` value is greater than 1, you can set the `dots` to  `true` if you want to render the slider with dots. |
 | onBeforeChange | Function | NOOP | `onBeforeChange` will be triggered when `ontouchstart` or `onmousedown` is triggered. |
 | onChange | Function | NOOP | `onChange` will be triggered while the value of Slider changing. |
 | onChangeComplete | Function | NOOP | `onChangeComplete` will be triggered when `ontouchend` or `onmouseup` is triggered. |
-| onDisabledChange | (disabled: boolean[]) => void | - | Callback when disabled array needs to be updated (e.g., when handles are added/removed in editable mode). Use with `disabled` as array to keep disabled states in sync. |
 | minimumTrackStyle | Object |  | please use  `trackStyle` instead. (`only used for slider, just for compatibility , will be deprecate at rc-slider@9.x `) |
 | maximumTrackStyle | Object |  | please use  `railStyle` instead (`only used for slider, just for compatibility , will be deprecate at rc-slider@9.x`) |
 | handleStyle | Array[Object] \| Object | `[{}]` | The style used for handle. (`both for slider(`Object`) and range(`Array of Object`), the array will be used for multi handle following element order`) |

--- a/README.md
+++ b/README.md
@@ -108,12 +108,13 @@ The following APIs are shared by Slider and Range.
 | handle | (props) => React.ReactNode | | A handle generator which could be used to customized handle. |
 | included | boolean | `true` | If the value is `true`, it means a continuous value interval, otherwise, it is a independent value. |
 | reverse | boolean | `false` | If the value is `true`, it means the component is rendered reverse. |
-| disabled | boolean | `false` | If `true`, handles can't be moved. |
+| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. Can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. |
 | keyboard | boolean | `true` | Support using keyboard to move handlers. |
 | dots | boolean | `false` | When the `step` value is greater than 1, you can set the `dots` to  `true` if you want to render the slider with dots. |
 | onBeforeChange | Function | NOOP | `onBeforeChange` will be triggered when `ontouchstart` or `onmousedown` is triggered. |
 | onChange | Function | NOOP | `onChange` will be triggered while the value of Slider changing. |
 | onChangeComplete | Function | NOOP | `onChangeComplete` will be triggered when `ontouchend` or `onmouseup` is triggered. |
+| onDisabledChange | (disabled: boolean[]) => void | - | Callback when disabled array needs to be updated (e.g., when handles are added/removed in editable mode). Use with `disabled` as array to keep disabled states in sync. |
 | minimumTrackStyle | Object |  | please use  `trackStyle` instead. (`only used for slider, just for compatibility , will be deprecate at rc-slider@9.x `) |
 | maximumTrackStyle | Object |  | please use  `railStyle` instead (`only used for slider, just for compatibility , will be deprecate at rc-slider@9.x`) |
 | handleStyle | Array[Object] \| Object | `[{}]` | The style used for handle. (`both for slider(`Object`) and range(`Array of Object`), the array will be used for multi handle following element order`) |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following APIs are shared by Slider and Range.
 | handle | (props) => React.ReactNode | | A handle generator which could be used to customized handle. |
 | included | boolean | `true` | If the value is `true`, it means a continuous value interval, otherwise, it is a independent value. |
 | reverse | boolean | `false` | If the value is `true`, it means the component is rendered reverse. |
-| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. This prop can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. When disabled is an array with any `true` value, `editable` mode will be disabled. |
+| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. This prop can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. When any rendered handle is disabled, `editable` mode will be disabled. |
 | keyboard | boolean | `true` | Support using keyboard to move handlers. |
 | dots | boolean | `false` | When the `step` value is greater than 1, you can set the `dots` to  `true` if you want to render the slider with dots. |
 | onBeforeChange | Function | NOOP | `onBeforeChange` will be triggered when `ontouchstart` or `onmousedown` is triggered. |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following APIs are shared by Slider and Range.
 | handle | (props) => React.ReactNode | | A handle generator which could be used to customized handle. |
 | included | boolean | `true` | If the value is `true`, it means a continuous value interval, otherwise, it is a independent value. |
 | reverse | boolean | `false` | If the value is `true`, it means the component is rendered reverse. |
-| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. Can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. |
+| disabled | boolean \| boolean[] | `false` | If `true`, handles can't be moved. This prop can also be an array to disable specific handles in range mode, e.g. `[true, false, true]` disables first and third handles. |
 | keyboard | boolean | `true` | Support using keyboard to move handlers. |
 | dots | boolean | `false` | When the `step` value is greater than 1, you can set the `dots` to  `true` if you want to render the slider with dots. |
 | onBeforeChange | Function | NOOP | `onBeforeChange` will be triggered when `ontouchstart` or `onmousedown` is triggered. |

--- a/assets/index.less
+++ b/assets/index.less
@@ -105,6 +105,20 @@
       cursor: -webkit-grabbing;
       cursor: grabbing;
     }
+
+    &-disabled {
+      background-color: #fff;
+      border-color: @disabledColor;
+      box-shadow: none;
+      cursor: not-allowed;
+
+      &:hover,
+      &:active {
+        border-color: @disabledColor;
+        box-shadow: none;
+        cursor: not-allowed;
+      }
+    }
   }
 
   &-mark {

--- a/docs/demo/disabled-handle.md
+++ b/docs/demo/disabled-handle.md
@@ -1,0 +1,9 @@
+---
+title: Disabled Handle
+title.zh-CN: 禁用特定滑块
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/disabled-handle.tsx"></code>

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -26,12 +26,13 @@ const EditableWithDisabled = () => {
         disabled={disabled}
         onDisabledChange={setDisabled}
       />
+      Slider disabled {JSON.stringify(disabled)}
       <div style={{ marginTop: 16 }}>
         {value.map((val, index) => (
           <label key={index} style={{ marginRight: 16 }}>
             <input
               type="checkbox"
-              checked={disabled[index]}
+              checked={!!disabled[index]}
               onChange={() => {
                 const newDisabled = [...disabled];
                 newDisabled[index] = !newDisabled[index];
@@ -56,12 +57,13 @@ const BasicDisabledHandle = () => {
   return (
     <div>
       <Slider range={{ draggableTrack: true }} value={value} onChange={(v) => setValue(v as number[])} disabled={disabled} />
+      Slider disabled {JSON.stringify(disabled)}
       <div style={{ marginTop: 16 }}>
         {value.map((val, index) => (
           <label key={index} style={{ marginRight: 16 }}>
             <input
               type="checkbox"
-              checked={disabled[index]}
+              checked={!!disabled[index]}
               onChange={() => {
                 const newDisabled = [...disabled];
                 newDisabled[index] = !newDisabled[index];
@@ -98,7 +100,7 @@ const SingleSlider = () => {
   return (
     <div>
       <Slider value={value1} onChange={(v) => setValue1(v as number)} disabled />
-        <br/>
+      <br />
       <Slider value={value2} onChange={(v) => setValue2(v as number)} disabled={false} />
     </div>
   );

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -1,0 +1,113 @@
+/* eslint react/no-multi-comp: 0, no-console: 0 */
+import Slider from '@rc-component/slider';
+import React, { useState } from 'react';
+import '../../assets/index.less';
+
+const style: React.CSSProperties = {
+  width: 400,
+  margin: 50,
+};
+
+// Basic editable with disabled handles
+const EditableWithDisabled = () => {
+  const [value, setValue] = useState<number[]>([0, 30, 100]);
+  const [disabled, setDisabled] = useState<boolean[]>([true, false, true]);
+
+  return (
+    <div>
+      <Slider
+        range={{
+          editable: true,
+          minCount: 2,
+          maxCount: 5,
+        }}
+        value={value}
+        onChange={(v) => setValue(v as number[])}
+        disabled={disabled}
+      />
+      <div style={{ marginTop: 16 }}>
+        {value.map((val, index) => (
+          <label key={index} style={{ marginRight: 16 }}>
+            <input
+              type="checkbox"
+              checked={disabled[index]}
+              onChange={() => {
+                const newDisabled = [...disabled];
+                newDisabled[index] = !newDisabled[index];
+                setDisabled(newDisabled);
+              }}
+            />
+            Handle {index + 1} ({val}) {disabled[index] ? 'Disabled' : 'Enabled'}
+          </label>
+        ))}
+      </div>
+      <p style={{ marginTop: 8, color: '#999', fontSize: 12 }}>
+        Try: Click track to add handle • Drag handle to edge to delete • Toggle checkboxes to disable handles
+      </p>
+    </div>
+  );
+};
+
+const BasicDisabledHandle = () => {
+  const [value, setValue] = useState<number[]>([0, 30, 60, 100]);
+  const [disabled, setDisabled] = useState([true]);
+
+  return (
+    <div>
+      <Slider range={{ draggableTrack: true }} value={value} onChange={(v) => setValue(v as number[])} disabled={disabled} />
+      <div style={{ marginTop: 16 }}>
+        {value.map((val, index) => (
+          <label key={index} style={{ marginRight: 16 }}>
+            <input
+              type="checkbox"
+              checked={disabled[index]}
+              onChange={() => {
+                const newDisabled = [...disabled];
+                newDisabled[index] = !newDisabled[index];
+                setDisabled(newDisabled);
+              }}
+            />
+            Handle {index + 1} ({val}) {disabled[index] ? 'Disabled' : 'Enabled'}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DisabledHandleAsBoundary = () => {
+  const [value, setValue] = useState<number[]>([10, 50, 90]);
+
+  return (
+    <div>
+      <Slider range value={value} onChange={(v) => setValue(v as number[])} disabled={[false, true, false]} />
+      <p style={{ marginTop: 8, color: '#999' }}>
+        Middle handle (50) is disabled and acts as a boundary.
+        First handle cannot go beyond 50, third handle cannot go below 50.
+        Disabled handle has gray border and not-allowed cursor.
+      </p>
+    </div>
+  );
+};
+
+export default () => (
+  <div>
+    <div style={style}>
+      <h3>Disabled Handle + Draggable Track</h3>
+      <p>Toggle checkboxes to disable/enable specific handles. Drag the track area to move the range.</p>
+      <BasicDisabledHandle />
+    </div>
+
+    <div style={style}>
+      <h3>Disabled Handle as Boundary</h3>
+      <DisabledHandleAsBoundary />
+    </div>
+    <div>
+      <div style={style}>
+        <h3>Editable + Disabled Array</h3>
+        <p>Toggle checkboxes to enable/disable handles in editable mode</p>
+        <EditableWithDisabled />
+      </div>
+    </div>
+  </div>
+);

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -45,7 +45,7 @@ const DisabledHandleAsBoundary = () => {
         range
         step={10}
         value={value}
-        onChange={(v) => setValue(v as number[])}
+        onChange={(v) => Array.isArray(v) && setValue(v)}
         disabled={[false, true, false]}
       />
       <p style={{ marginTop: 8, color: '#999' }}>

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -10,7 +10,7 @@ const style: React.CSSProperties = {
 
 const defaultValue = [0, 30, 60, 100];
 const BasicDisabledHandle = () => {
-  const [disabled, setDisabled] = useState([true]);
+  const [disabled, setDisabled] = useState([true, false, false, false]);
 
   return (
     <div>
@@ -144,9 +144,10 @@ export default () => (
       <SingleSlider />
     </div>
     <div style={style}>
-      <h3>Disabled Handle + Draggable Track</h3>
+      <h3>Disabled Handle</h3>
       <p>
-        Toggle checkboxes to disable/enable specific handles. Drag the track area to move the range.
+        Toggle checkboxes to disable/enable specific handles. Track dragging is disabled when any
+        handle is disabled.
       </p>
       <BasicDisabledHandle />
     </div>

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -49,17 +49,16 @@ const EditableWithDisabled = () => {
     </div>
   );
 };
-
+const defaultValue = [0, 30, 60, 100];
 const BasicDisabledHandle = () => {
-  const [value, setValue] = useState<number[]>([0, 30, 60, 100]);
   const [disabled, setDisabled] = useState([true]);
 
   return (
     <div>
-      <Slider range={{ draggableTrack: true }} value={value} onChange={(v) => setValue(v as number[])} disabled={disabled} />
+      <Slider range={{ draggableTrack: true }} defaultValue={defaultValue} disabled={disabled} />
       Slider disabled {JSON.stringify(disabled)}
       <div style={{ marginTop: 16 }}>
-        {value.map((val, index) => (
+        {defaultValue.map((_, index) => (
           <label key={index} style={{ marginRight: 16 }}>
             <input
               type="checkbox"
@@ -70,7 +69,7 @@ const BasicDisabledHandle = () => {
                 setDisabled(newDisabled);
               }}
             />
-            Handle {index + 1} ({val}) {disabled[index] ? 'Disabled' : 'Enabled'}
+            Handle {index + 1} {disabled[index] ? 'Disabled' : 'Enabled'}
           </label>
         ))}
       </div>
@@ -111,9 +110,6 @@ export default () => (
     <div>
       single handle disabled
       <SingleSlider />
-    </div>
-    <div>
-
     </div>
     <div style={style}>
       <h3>Disabled Handle + Draggable Track</h3>

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -8,48 +8,6 @@ const style: React.CSSProperties = {
   margin: 50,
 };
 
-// Basic editable with disabled handles
-const EditableWithDisabled = () => {
-  const [value, setValue] = useState<number[]>([0, 30, 100]);
-  const [disabled, setDisabled] = useState<boolean[]>([true, false, true]);
-
-  return (
-    <div>
-      <Slider
-        range={{
-          editable: true,
-          minCount: 2,
-          maxCount: 5,
-        }}
-        value={value}
-        onChange={(v) => setValue(v as number[])}
-        disabled={disabled}
-        onDisabledChange={setDisabled}
-      />
-      Slider disabled {JSON.stringify(disabled)}
-      <div style={{ marginTop: 16 }}>
-        {value.map((val, index) => (
-          <label key={index} style={{ marginRight: 16 }}>
-            <input
-              type="checkbox"
-              checked={!!disabled[index]}
-              onChange={() => {
-                const newDisabled = [...disabled];
-                newDisabled[index] = !newDisabled[index];
-                setDisabled(newDisabled);
-              }}
-            />
-            Handle {index + 1} ({val}) {disabled[index] ? 'Disabled' : 'Enabled'}
-          </label>
-        ))}
-      </div>
-      <p style={{ marginTop: 8, color: '#999', fontSize: 12 }}>
-        Try: Click track to add handle • Drag handle to edge to delete • Toggle checkboxes to
-        disable handles
-      </p>
-    </div>
-  );
-};
 const defaultValue = [0, 30, 60, 100];
 const BasicDisabledHandle = () => {
   const [disabled, setDisabled] = useState([true]);
@@ -85,6 +43,7 @@ const DisabledHandleAsBoundary = () => {
     <div>
       <Slider
         range
+        step={10}
         value={value}
         onChange={(v) => setValue(v as number[])}
         disabled={[false, true, false]}
@@ -130,6 +89,54 @@ const SingleSlider = () => {
   );
 };
 
+// Editable mode with disabled handles - editable is disabled when any handle is disabled
+const EditableWithDisabled = () => {
+  const [value, setValue] = useState<number[]>([0, 30, 100]);
+  const [disabled, setDisabled] = useState<boolean[]>([true, false, false]);
+
+  const hasDisabled = disabled.some((d) => d);
+
+  return (
+    <div>
+      <Slider
+        range={{
+          editable: true,
+          minCount: 2,
+          maxCount: 5,
+        }}
+        value={value}
+        onChange={(v) => setValue(v as number[])}
+        disabled={disabled}
+      />
+      <p style={{ marginTop: 8, color: hasDisabled ? '#f5222d' : '#52c41a' }}>
+        {hasDisabled
+          ? 'Editable mode is DISABLED because at least one handle is disabled. Clicking track will move nearest enabled handle.'
+          : 'Editable mode is ENABLED. Click track to add handles, drag to edge to delete.'}
+      </p>
+      <div style={{ marginTop: 16 }}>
+        {value.map((val, index) => (
+          <label key={index} style={{ marginRight: 16 }}>
+            <input
+              type="checkbox"
+              checked={!!disabled[index]}
+              onChange={() => {
+                const newDisabled = [...disabled];
+                newDisabled[index] = !newDisabled[index];
+                setDisabled(newDisabled);
+              }}
+            />
+            Handle {index + 1} ({val}) {disabled[index] ? 'Disabled' : 'Enabled'}
+          </label>
+        ))}
+      </div>
+      <p style={{ marginTop: 8, color: '#999', fontSize: 12 }}>
+        Try: Toggle checkboxes to enable/disable handles. When any handle is disabled, you cannot
+        add or remove handles. When all handles are enabled, editable mode works normally.
+      </p>
+    </div>
+  );
+};
+
 export default () => (
   <div>
     <div>
@@ -153,12 +160,10 @@ export default () => (
       <h3>Disabled Handle + Pushable</h3>
       <PushableWithDisabledHandle />
     </div>
-    <div>
-      <div style={style}>
-        <h3>Editable + Disabled Array</h3>
-        <p>Toggle checkboxes to enable/disable handles in editable mode</p>
-        <EditableWithDisabled />
-      </div>
+
+    <div style={style}>
+      <h3>Editable + Disabled (Editable Disabled When Any Handle Disabled)</h3>
+      <EditableWithDisabled />
     </div>
   </div>
 );

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -24,6 +24,7 @@ const EditableWithDisabled = () => {
         value={value}
         onChange={(v) => setValue(v as number[])}
         disabled={disabled}
+        onDisabledChange={setDisabled}
       />
       <div style={{ marginTop: 16 }}>
         {value.map((val, index) => (
@@ -90,8 +91,28 @@ const DisabledHandleAsBoundary = () => {
   );
 };
 
+const SingleSlider = () => {
+  const [value1, setValue1] = useState(30);
+  const [value2, setValue2] = useState(30);
+
+  return (
+    <div>
+      <Slider value={value1} onChange={(v) => setValue1(v as number)} disabled />
+        <br/>
+      <Slider value={value2} onChange={(v) => setValue2(v as number)} disabled={false} />
+    </div>
+  );
+}
+
 export default () => (
   <div>
+    <div>
+      single handle disabled
+      <SingleSlider />
+    </div>
+    <div>
+
+    </div>
     <div style={style}>
       <h3>Disabled Handle + Draggable Track</h3>
       <p>Toggle checkboxes to disable/enable specific handles. Drag the track area to move the range.</p>

--- a/docs/examples/disabled-handle.tsx
+++ b/docs/examples/disabled-handle.tsx
@@ -44,7 +44,8 @@ const EditableWithDisabled = () => {
         ))}
       </div>
       <p style={{ marginTop: 8, color: '#999', fontSize: 12 }}>
-        Try: Click track to add handle • Drag handle to edge to delete • Toggle checkboxes to disable handles
+        Try: Click track to add handle • Drag handle to edge to delete • Toggle checkboxes to
+        disable handles
       </p>
     </div>
   );
@@ -82,11 +83,35 @@ const DisabledHandleAsBoundary = () => {
 
   return (
     <div>
-      <Slider range value={value} onChange={(v) => setValue(v as number[])} disabled={[false, true, false]} />
+      <Slider
+        range
+        value={value}
+        onChange={(v) => setValue(v as number[])}
+        disabled={[false, true, false]}
+      />
       <p style={{ marginTop: 8, color: '#999' }}>
-        Middle handle (50) is disabled and acts as a boundary.
-        First handle cannot go beyond 50, third handle cannot go below 50.
-        Disabled handle has gray border and not-allowed cursor.
+        Middle handle (50) is disabled and acts as a boundary. First handle cannot go beyond 50,
+        third handle cannot go below 50. Disabled handle has gray border and not-allowed cursor.
+      </p>
+    </div>
+  );
+};
+
+const PushableWithDisabledHandle = () => {
+  const [value, setValue] = useState<number[]>([20, 40, 60, 80]);
+
+  return (
+    <div>
+      <Slider
+        range
+        value={value}
+        onChange={(v) => setValue(v as number[])}
+        disabled={[false, true, false, false]}
+        pushable={10}
+      />
+      <p style={{ marginTop: 8, color: '#999' }}>
+        Second handle (40) is disabled. Drag the first handle toward it or push the last two handles
+        together: enabled handles keep at least 10 apart without crossing the disabled handle.
       </p>
     </div>
   );
@@ -103,7 +128,7 @@ const SingleSlider = () => {
       <Slider value={value2} onChange={(v) => setValue2(v as number)} disabled={false} />
     </div>
   );
-}
+};
 
 export default () => (
   <div>
@@ -113,13 +138,20 @@ export default () => (
     </div>
     <div style={style}>
       <h3>Disabled Handle + Draggable Track</h3>
-      <p>Toggle checkboxes to disable/enable specific handles. Drag the track area to move the range.</p>
+      <p>
+        Toggle checkboxes to disable/enable specific handles. Drag the track area to move the range.
+      </p>
       <BasicDisabledHandle />
     </div>
 
     <div style={style}>
       <h3>Disabled Handle as Boundary</h3>
       <DisabledHandleAsBoundary />
+    </div>
+
+    <div style={style}>
+      <h3>Disabled Handle + Pushable</h3>
+      <PushableWithDisabledHandle />
     </div>
     <div>
       <div style={style}>

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -68,8 +68,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     isHandleDisabled,
   } = React.useContext(SliderContext);
 
-  const handleDisabled =
-    globalDisabled || (isHandleDisabled ? isHandleDisabled(valueIndex) : false);
+  const handleDisabled = globalDisabled || isHandleDisabled(valueIndex);
 
   const handlePrefixCls = `${prefixCls}-handle`;
 

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -55,7 +55,6 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     min,
     max,
     direction,
-    disabled: globalDisabled,
     keyboard,
     range,
     tabIndex,
@@ -68,13 +67,13 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     isHandleDisabled,
   } = React.useContext(SliderContext);
 
-  const handleDisabled = globalDisabled || isHandleDisabled(valueIndex);
+  const mergedDisabled = isHandleDisabled(valueIndex);
 
   const handlePrefixCls = `${prefixCls}-handle`;
 
   // ============================ Events ============================
   const onInternalStartMove = (e: React.MouseEvent | React.TouchEvent) => {
-    if (handleDisabled) {
+    if (mergedDisabled) {
       e.stopPropagation();
       return;
     }
@@ -91,7 +90,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
 
   // =========================== Keyboard ===========================
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
-    if (!handleDisabled && keyboard) {
+    if (!mergedDisabled && keyboard) {
       let offset: number | 'min' | 'max' = null;
 
       // Change the value
@@ -166,12 +165,12 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
 
   if (valueIndex !== null) {
     divProps = {
-      tabIndex: handleDisabled ? null : getIndex(tabIndex, valueIndex),
+      tabIndex: mergedDisabled ? null : getIndex(tabIndex, valueIndex),
       role: 'slider',
       'aria-valuemin': min,
       'aria-valuemax': max,
       'aria-valuenow': value,
-      'aria-disabled': handleDisabled,
+      'aria-disabled': mergedDisabled,
       'aria-label': getIndex(ariaLabelForHandle, valueIndex),
       'aria-labelledby': getIndex(ariaLabelledByForHandle, valueIndex),
       'aria-required': getIndex(ariaRequired, valueIndex),
@@ -195,7 +194,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
           [`${handlePrefixCls}-${valueIndex + 1}`]: valueIndex !== null && range,
           [`${handlePrefixCls}-dragging`]: dragging,
           [`${handlePrefixCls}-dragging-delete`]: draggingDelete,
-          [`${handlePrefixCls}-disabled`]: handleDisabled,
+          [`${handlePrefixCls}-disabled`]: mergedDisabled,
         },
         classNames.handle,
       )}

--- a/src/Handles/Handle.tsx
+++ b/src/Handles/Handle.tsx
@@ -55,7 +55,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     min,
     max,
     direction,
-    disabled,
+    disabled: globalDisabled,
     keyboard,
     range,
     tabIndex,
@@ -65,15 +65,21 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
     ariaValueTextFormatterForHandle,
     styles,
     classNames,
+    isHandleDisabled,
   } = React.useContext(SliderContext);
+
+  const handleDisabled =
+    globalDisabled || (isHandleDisabled ? isHandleDisabled(valueIndex) : false);
 
   const handlePrefixCls = `${prefixCls}-handle`;
 
   // ============================ Events ============================
   const onInternalStartMove = (e: React.MouseEvent | React.TouchEvent) => {
-    if (!disabled) {
-      onStartMove(e, valueIndex);
+    if (handleDisabled) {
+      e.stopPropagation();
+      return;
     }
+    onStartMove(e, valueIndex);
   };
 
   const onInternalFocus = (e: React.FocusEvent<HTMLDivElement>) => {
@@ -86,7 +92,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
 
   // =========================== Keyboard ===========================
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
-    if (!disabled && keyboard) {
+    if (!handleDisabled && keyboard) {
       let offset: number | 'min' | 'max' = null;
 
       // Change the value
@@ -161,12 +167,12 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
 
   if (valueIndex !== null) {
     divProps = {
-      tabIndex: disabled ? null : getIndex(tabIndex, valueIndex),
+      tabIndex: handleDisabled ? null : getIndex(tabIndex, valueIndex),
       role: 'slider',
       'aria-valuemin': min,
       'aria-valuemax': max,
       'aria-valuenow': value,
-      'aria-disabled': disabled,
+      'aria-disabled': handleDisabled,
       'aria-label': getIndex(ariaLabelForHandle, valueIndex),
       'aria-labelledby': getIndex(ariaLabelledByForHandle, valueIndex),
       'aria-required': getIndex(ariaRequired, valueIndex),
@@ -190,6 +196,7 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>((props, ref) => {
           [`${handlePrefixCls}-${valueIndex + 1}`]: valueIndex !== null && range,
           [`${handlePrefixCls}-dragging`]: dragging,
           [`${handlePrefixCls}-dragging-delete`]: draggingDelete,
+          [`${handlePrefixCls}-disabled`]: handleDisabled,
         },
         classNames.handle,
       )}

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -14,7 +14,7 @@ import type { SliderContextProps } from './context';
 import SliderContext from './context';
 import useDisabled from './hooks/useDisabled';
 import useDrag from './hooks/useDrag';
-import useOffset, { getClosestEnabledHandleIndex } from './hooks/useOffset';
+import useOffset, { getClosestEnabledHandleIndex, useFormatValue } from './hooks/useOffset';
 import useRange from './hooks/useRange';
 import type {
   AriaValueFormat,
@@ -242,18 +242,12 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       .sort((a, b) => a.value - b.value);
   }, [marks]);
 
-  // ============================ Disabled ============================
-  const [isHandleDisabled, getDisabledState] = useDisabled(rawDisabled);
-
   // ============================ Format ============================
-  const [formatValue, offsetValues] = useOffset(
+  const formatValue = useFormatValue(
     mergedMin,
     mergedMax,
     mergedStep as number,
     markList,
-    allowCross,
-    mergedPush as false | number,
-    isHandleDisabled,
   );
 
   // ============================ Values ============================
@@ -293,9 +287,18 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     return returnValues;
   }, [mergedValue, rangeEnabled, mergedMin, count, formatValue]);
 
-  const [disabled, hasDisabledHandle] = React.useMemo(
-    () => getDisabledState(rawValues),
-    [getDisabledState, rawValues],
+  // ============================ Disabled ============================
+  const [isHandleDisabled, disabled, hasDisabledHandle] = useDisabled(rawDisabled, rawValues);
+
+  const offsetValues = useOffset(
+    mergedMin,
+    mergedMax,
+    mergedStep as number,
+    markList,
+    allowCross,
+    mergedPush as false | number,
+    formatValue,
+    isHandleDisabled,
   );
 
   const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -189,18 +189,19 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
   const handlesRef = React.useRef<HandlesRef>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const [mergedValue, setValue] = useControlledState(defaultValue, value);
 
   // ============================ Disabled ============================
   const disabled = React.useMemo(() => {
     if (typeof rawDisabled === 'boolean') {
       return rawDisabled;
     }
-    if (Array.isArray(value)) {
-      return value.every((_, index) => rawDisabled[index]);
+    if (Array.isArray(rawDisabled)) {
+      const values = Array.isArray(mergedValue) ? mergedValue : [mergedValue];
+      return values.every((_, index) => rawDisabled[index]);
     }
-
     return false;
-  }, [rawDisabled, value]);
+  }, [rawDisabled, mergedValue]);
 
   const isHandleDisabled = React.useCallback(
     (index: number) => {
@@ -275,7 +276,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   );
 
   // ============================ Values ============================
-  const [mergedValue, setValue] = useControlledState(defaultValue, value);
 
   const rawValues = React.useMemo(() => {
     const valueList =
@@ -330,8 +330,9 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       const newDisabled = [...rawDisabled];
 
       if (cloneNextValues.length > rawValues.length) {
-        const index = cloneNextValues.findIndex((item) => !rawValues.includes(item));
-        newDisabled.splice(index, 0, false);
+        const index = cloneNextValues.findIndex((item, i) => item !== rawValues[i]);
+        const insertIndex = index === -1 ? rawValues.length : index;
+        newDisabled.splice(insertIndex, 0, false);
       } else if (cloneNextValues.length < rawValues.length) {
         const index = rawValues.findIndex((item) => !cloneNextValues.includes(item));
         newDisabled.splice(index, 1);

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -455,7 +455,25 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
           valueIndex = nearestIndex;
         }
-        cloneNextValues[valueIndex] = newValue;
+
+        // Apply boundary constraints from disabled handles
+        let minBound = mergedMin;
+        let maxBound = mergedMax;
+
+        for (let i = valueIndex - 1; i >= 0; i -= 1) {
+          if (isHandleDisabled(i)) {
+            minBound = rawValues[i];
+            break;
+          }
+        }
+        for (let i = valueIndex + 1; i < rawValues.length; i += 1) {
+          if (isHandleDisabled(i)) {
+            maxBound = rawValues[i];
+            break;
+          }
+        }
+
+        cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
         focusIndex = valueIndex;
       }
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -14,7 +14,7 @@ import type { SliderContextProps } from './context';
 import SliderContext from './context';
 import useDisabled from './hooks/useDisabled';
 import useDrag from './hooks/useDrag';
-import useOffset from './hooks/useOffset';
+import useOffset, { getClosestEnabledHandleIndex } from './hooks/useOffset';
 import useRange from './hooks/useRange';
 import type {
   AriaValueFormat,
@@ -402,44 +402,24 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
-        // Find nearest enabled handle if current is disabled
-        if (isHandleDisabled(valueIndex)) {
-          const enabledIndices = rawValues
-            .map((_, i) => i)
-            .filter((i) => !isHandleDisabled(i));
-
-          if (enabledIndices.length === 0) return;
-
-          valueIndex = enabledIndices.reduce((nearest, i) =>
-            Math.abs(newValue - rawValues[i]) < Math.abs(newValue - rawValues[nearest]) ? i : nearest,
-          );
-        }
-
-        // Calculate boundaries from disabled handles (treat as fixed anchors)
-        const pushDist = typeof mergedPush === 'number' ? mergedPush : 0;
-        let minBound = mergedMin;
-        let maxBound = mergedMax;
-
-        // Find nearest disabled handle on the left as min boundary
-        for (let i = valueIndex - 1; i >= 0; i -= 1) {
-          if (isHandleDisabled(i)) {
-            minBound = Math.max(minBound, rawValues[i] + pushDist);
-            break;
-          }
-        }
-
-        // Find nearest disabled handle on the right as max boundary
-        for (let i = valueIndex + 1; i < rawValues.length; i += 1) {
-          if (isHandleDisabled(i)) {
-            maxBound = Math.min(maxBound, rawValues[i] - pushDist);
-            break;
-          }
-        }
-
-        if (minBound <= maxBound) {
-          cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
+        if (!rawValues.length) {
+          cloneNextValues[valueIndex] = newValue;
         } else {
-          cloneNextValues[valueIndex] = rawValues[valueIndex];
+          const nextValueIndex = getClosestEnabledHandleIndex(
+            rawValues,
+            newValue,
+            mergedMin,
+            mergedMax,
+            mergedPush as false | number,
+            isHandleDisabled,
+          );
+
+          if (nextValueIndex === -1) {
+            return;
+          }
+
+          valueIndex = nextValueIndex;
+          cloneNextValues[valueIndex] = newValue;
         }
         focusIndex = valueIndex;
       }
@@ -500,7 +480,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   };
 
   // =========================== Keyboard ===========================
-  const [keyboardValue, setKeyboardValue] = React.useState<number>(null!);
+  const [keyboardValue, setKeyboardValue] = React.useState<{ value: number; index: number }>(null!);
 
   const onHandleOffsetChange = (offset: number | 'min' | 'max', valueIndex: number) => {
     if (!disabled && !isHandleDisabled(valueIndex)) {
@@ -509,13 +489,15 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       onBeforeChange?.(getTriggerValue(rawValues));
       triggerChange(next.values);
 
-      setKeyboardValue(next.value);
+      setKeyboardValue({ value: next.value, index: valueIndex });
     }
   };
 
   React.useEffect(() => {
     if (keyboardValue !== null) {
-      const valueIndex = rawValues.indexOf(keyboardValue);
+      const { value: nextKeyboardValue, index } = keyboardValue;
+      const valueIndex =
+        rawValues[index] === nextKeyboardValue ? index : rawValues.indexOf(nextKeyboardValue);
       if (valueIndex >= 0) {
         handlesRef.current!.focus(valueIndex);
       }

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -329,7 +329,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   });
 
   const onDelete = (index: number) => {
-    if (disabled || !effectiveRangeEditable || rawValues.length <= minCount || isHandleDisabled(index)) {
+    if (disabled || !effectiveRangeEditable || rawValues.length <= minCount) {
       return;
     }
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -333,7 +333,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
         const insertIndex = index === -1 ? rawValues.length : index;
         newDisabled.splice(insertIndex, 0, false);
       } else if (cloneNextValues.length < rawValues.length) {
-        const index = rawValues.findIndex((item) => !cloneNextValues.includes(item));
+        const index = rawValues.findIndex((item, i) => item !== cloneNextValues[i]);
         newDisabled.splice(index, 1);
       }
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -12,6 +12,7 @@ import Steps from './Steps';
 import Tracks from './Tracks';
 import type { SliderContextProps } from './context';
 import SliderContext from './context';
+import useDisabled from './hooks/useDisabled';
 import useDrag from './hooks/useDrag';
 import useOffset from './hooks/useOffset';
 import useRange from './hooks/useRange';
@@ -189,27 +190,8 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   const [mergedValue, setValue] = useControlledState(defaultValue, value);
 
   // ============================ Disabled ============================
-  const disabled = React.useMemo(() => {
-    if (typeof rawDisabled === 'boolean') {
-      return rawDisabled;
-    }
-    if (Array.isArray(rawDisabled)) {
-      const values = Array.isArray(mergedValue) ? mergedValue : [mergedValue];
-      return values.every((_, index) => rawDisabled[index]);
-    }
-    return false;
-  }, [rawDisabled, mergedValue]);
 
-  const isHandleDisabled = React.useCallback(
-    (index: number) => {
-      if (typeof rawDisabled === 'boolean') {
-        return rawDisabled;
-      }
-      // Return individual disabled state if defined, otherwise fallback to global disabled
-      return rawDisabled[index] ?? disabled;
-    },
-    [rawDisabled, disabled],
-  );
+  const [disabled, isHandleDisabled, hasDisabledHandle] = useDisabled(rawDisabled, mergedValue);
 
   const direction = React.useMemo<Direction>(() => {
     if (vertical) {
@@ -220,14 +202,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
   // ============================ Range =============================
   const [rangeEnabled, rangeEditable, rangeDraggableTrack, minCount, maxCount] = useRange(range);
-
-  // Check if any handle is disabled - if so, disable all editable operations
-  const hasDisabledHandle = React.useMemo(() => {
-    if (typeof rawDisabled === 'boolean') {
-      return rawDisabled;
-    }
-    return rawDisabled.some((d) => d);
-  }, [rawDisabled]);
 
   // Disable editable when any handle is disabled
   const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -323,7 +323,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
     // Sync disabled array when values length changes (add/remove handles in editable mode)
     if (
-      typeof rawDisabled !== 'boolean' &&
       Array.isArray(rawDisabled) &&
       cloneNextValues.length !== rawValues.length
     ) {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -369,20 +369,30 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
    */
   const changeToCloseValue = (newValue: number, e?: React.MouseEvent) => {
     if (!disabled) {
+      const valueIndex = rawValues.length
+        ? getClosestEnabledHandleIndex(
+            rawValues,
+            newValue,
+            mergedMin,
+            mergedMax,
+            mergedPush as false | number,
+            isHandleDisabled,
+          )
+        : 0;
+
+      if (valueIndex === -1) {
+        return;
+      }
+
       // Create new values
       const cloneNextValues = [...rawValues];
 
-      let valueIndex = 0;
       let valueBeforeIndex = 0; // Record the index which value < newValue
-      let valueDist = mergedMax - mergedMin;
+      const valueDist = rawValues.length
+        ? Math.abs(newValue - rawValues[valueIndex])
+        : mergedMax - mergedMin;
 
       rawValues.forEach((val, index) => {
-        const dist = Math.abs(newValue - val);
-        if (dist <= valueDist) {
-          valueDist = dist;
-          valueIndex = index;
-        }
-
         if (val < newValue) {
           valueBeforeIndex = index;
         }
@@ -394,25 +404,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
-        if (!rawValues.length) {
-          cloneNextValues[valueIndex] = newValue;
-        } else {
-          const nextValueIndex = getClosestEnabledHandleIndex(
-            rawValues,
-            newValue,
-            mergedMin,
-            mergedMax,
-            mergedPush as false | number,
-            isHandleDisabled,
-          );
-
-          if (nextValueIndex === -1) {
-            return;
-          }
-
-          valueIndex = nextValueIndex;
-          cloneNextValues[valueIndex] = newValue;
-        }
+        cloneNextValues[valueIndex] = newValue;
         focusIndex = valueIndex;
       }
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -243,15 +243,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   }, [marks]);
 
   // ============================ Disabled ============================
-  const isHandleDisabled = React.useCallback(
-    (index: number): boolean => {
-      if (typeof rawDisabled === 'boolean') {
-        return rawDisabled;
-      }
-      return rawDisabled[index] ?? false;
-    },
-    [rawDisabled],
-  );
+  const [isHandleDisabled, getDisabledState] = useDisabled(rawDisabled);
 
   // ============================ Format ============================
   const [formatValue, offsetValues] = useOffset(
@@ -265,7 +257,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   );
 
   // ============================ Values ============================
-
   const rawValues = React.useMemo(() => {
     const valueList =
       mergedValue === null || mergedValue === undefined
@@ -302,7 +293,10 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     return returnValues;
   }, [mergedValue, rangeEnabled, mergedMin, count, formatValue]);
 
-  const [disabled, hasDisabledHandle] = useDisabled(rawDisabled, rawValues);
+  const [disabled, hasDisabledHandle] = React.useMemo(
+    () => getDisabledState(rawValues),
+    [getDisabledState, rawValues],
+  );
 
   const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -191,7 +191,17 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
   // ============================ Disabled ============================
 
-  const [disabled, isHandleDisabled, hasDisabledHandle] = useDisabled(rawDisabled, mergedValue);
+  const [disabled, hasDisabledHandle] = useDisabled(rawDisabled, mergedValue);
+
+  const isHandleDisabled = React.useCallback(
+    (index: number): boolean => {
+      if (typeof rawDisabled === 'boolean') {
+        return rawDisabled;
+      }
+      return rawDisabled[index] ?? false;
+    },
+    [rawDisabled],
+  );
 
   const direction = React.useMemo<Direction>(() => {
     if (vertical) {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -57,7 +57,7 @@ export interface SliderProps<ValueType = number | number[]> {
   id?: string;
 
   // Status
-  disabled?: boolean;
+  disabled?: boolean | boolean[];
   keyboard?: boolean;
   autoFocus?: boolean;
   onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
@@ -131,8 +131,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
     id,
 
-    // Status
-    disabled = false,
+    disabled: rawDisabled = false,
     keyboard = true,
     autoFocus,
     onFocus,
@@ -187,6 +186,25 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
   const handlesRef = React.useRef<HandlesRef>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
+
+  // ============================ Disabled ============================
+  const disabled = React.useMemo(() => {
+    if (typeof rawDisabled === 'boolean') {
+      return rawDisabled;
+    };
+
+    return Array.isArray(value) && value.length === rawDisabled.length && rawDisabled.every(Boolean);
+  }, [rawDisabled, value]);
+
+  const isHandleDisabled = React.useCallback(
+    (index: number) => {
+      if (typeof rawDisabled === 'boolean') {
+        return rawDisabled;
+      }
+      return rawDisabled[index] || false;
+    },
+    [rawDisabled],
+  );
 
   const direction = React.useMemo<Direction>(() => {
     if (vertical) {
@@ -247,6 +265,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     markList,
     allowCross,
     mergedPush,
+    isHandleDisabled,
   );
 
   // ============================ Values ============================
@@ -257,8 +276,8 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       mergedValue === null || mergedValue === undefined
         ? []
         : Array.isArray(mergedValue)
-        ? mergedValue
-        : [mergedValue];
+          ? mergedValue
+          : [mergedValue];
 
     const [val0 = mergedMin] = valueList;
     let returnValues = mergedValue === null ? [] : [val0];
@@ -321,7 +340,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   });
 
   const onDelete = (index: number) => {
-    if (disabled || !rangeEditable || rawValues.length <= minCount) {
+    if (disabled || !rangeEditable || rawValues.length <= minCount || isHandleDisabled(index)) {
       return;
     }
 
@@ -348,6 +367,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     offsetValues,
     rangeEditable,
     minCount,
+    isHandleDisabled,
   );
 
   /**
@@ -378,10 +398,39 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       let focusIndex = valueIndex;
 
       if (rangeEditable && valueDist !== 0 && (!maxCount || rawValues.length < maxCount)) {
+        const leftDisabled = isHandleDisabled(valueBeforeIndex);
+        const rightDisabled = isHandleDisabled(valueBeforeIndex + 1);
+
+        if (leftDisabled && rightDisabled) {
+          return;
+        }
+
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
+        if (isHandleDisabled(valueIndex)) {
+          let nearestIndex = -1;
+          let nearestDist = mergedMax - mergedMin;
+
+          rawValues.forEach((val, index) => {
+            if (!isHandleDisabled(index)) {
+              const dist = Math.abs(newValue - val);
+              if (dist < nearestDist) {
+                nearestDist = dist;
+                nearestIndex = index;
+              }
+            }
+          });
+
+          // If all handles are disabled, do nothing
+          if (nearestIndex === -1) {
+            return;
+          }
+
+          valueIndex = nearestIndex;
+        }
         cloneNextValues[valueIndex] = newValue;
+        focusIndex = valueIndex;
       }
 
       // Fill value to match default 2 (only when `rawValues` is empty)
@@ -443,7 +492,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   const [keyboardValue, setKeyboardValue] = React.useState<number>(null);
 
   const onHandleOffsetChange = (offset: number | 'min' | 'max', valueIndex: number) => {
-    if (!disabled) {
+    if (!disabled && !isHandleDisabled(valueIndex)) {
       const next = offsetValues(rawValues, offset, valueIndex);
 
       onBeforeChange?.(getTriggerValue(rawValues));
@@ -546,6 +595,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       ariaValueTextFormatterForHandle,
       styles: styles || {},
       classNames: classNames || {},
+      isHandleDisabled,
     }),
     [
       mergedMin,
@@ -565,6 +615,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       ariaValueTextFormatterForHandle,
       styles,
       classNames,
+      isHandleDisabled,
     ],
   );
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -14,7 +14,7 @@ import type { SliderContextProps } from './context';
 import SliderContext from './context';
 import useDisabled from './hooks/useDisabled';
 import useDrag from './hooks/useDrag';
-import useOffset, { getClosestEnabledHandleIndex, useFormatValue } from './hooks/useOffset';
+import useOffset, { getClosestEnabledHandleIndex } from './hooks/useOffset';
 import useRange from './hooks/useRange';
 import type {
   AriaValueFormat,
@@ -242,12 +242,18 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       .sort((a, b) => a.value - b.value);
   }, [marks]);
 
+  // ============================ Disabled ============================
+  const [isHandleDisabled, getDisabledState] = useDisabled(rawDisabled);
+
   // ============================ Format ============================
-  const formatValue = useFormatValue(
+  const [formatValue, offsetValues] = useOffset(
     mergedMin,
     mergedMax,
     mergedStep as number,
     markList,
+    allowCross,
+    mergedPush as false | number,
+    isHandleDisabled,
   );
 
   // ============================ Values ============================
@@ -287,18 +293,9 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     return returnValues;
   }, [mergedValue, rangeEnabled, mergedMin, count, formatValue]);
 
-  // ============================ Disabled ============================
-  const [isHandleDisabled, disabled, hasDisabledHandle] = useDisabled(rawDisabled, rawValues);
-
-  const offsetValues = useOffset(
-    mergedMin,
-    mergedMax,
-    mergedStep as number,
-    markList,
-    allowCross,
-    mergedPush as false | number,
-    formatValue,
-    isHandleDisabled,
+  const [disabled, hasDisabledHandle] = React.useMemo(
+    () => getDisabledState(rawValues),
+    [getDisabledState, rawValues],
   );
 
   const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -189,20 +189,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [mergedValue, setValue] = useControlledState(defaultValue, value);
 
-  // ============================ Disabled ============================
-
-  const [disabled, hasDisabledHandle] = useDisabled(rawDisabled, mergedValue);
-
-  const isHandleDisabled = React.useCallback(
-    (index: number): boolean => {
-      if (typeof rawDisabled === 'boolean') {
-        return rawDisabled;
-      }
-      return rawDisabled[index] ?? false;
-    },
-    [rawDisabled],
-  );
-
   const direction = React.useMemo<Direction>(() => {
     if (vertical) {
       return reverse ? 'ttb' : 'btt';
@@ -213,8 +199,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   // ============================ Range =============================
   const [rangeEnabled, rangeEditable, rangeDraggableTrack, minCount, maxCount] = useRange(range);
 
-  // Disable editable when any handle is disabled
-  const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;
+
 
   const mergedMin = React.useMemo(() => (isFinite(min) ? min : 0), [min]);
   const mergedMax = React.useMemo(() => (isFinite(max) ? max : 100), [max]);
@@ -256,6 +241,17 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       .filter(({ label }) => label || typeof label === 'number')
       .sort((a, b) => a.value - b.value);
   }, [marks]);
+
+  // ============================ Disabled ============================
+  const isHandleDisabled = React.useCallback(
+    (index: number): boolean => {
+      if (typeof rawDisabled === 'boolean') {
+        return rawDisabled;
+      }
+      return rawDisabled[index] ?? false;
+    },
+    [rawDisabled],
+  );
 
   // ============================ Format ============================
   const [formatValue, offsetValues] = useOffset(
@@ -305,6 +301,10 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
     return returnValues;
   }, [mergedValue, rangeEnabled, mergedMin, count, formatValue]);
+
+  const [disabled, hasDisabledHandle] = useDisabled(rawDisabled, rawValues);
+
+  const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;
 
   // =========================== onChange ===========================
   const getTriggerValue = (triggerValues: number[]) =>

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -78,8 +78,6 @@ export interface SliderProps<ValueType = number | number[]> {
   /** @deprecated Use `onChangeComplete` instead */
   onAfterChange?: (value: ValueType) => void;
   onChangeComplete?: (value: ValueType) => void;
-  /** Callback when disabled array needs to be updated (e.g., when handles are added/removed in editable mode) */
-  onDisabledChange?: (disabled: boolean[]) => void;
 
   // Cross
   allowCross?: boolean;
@@ -151,7 +149,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     onBeforeChange,
     onAfterChange,
     onChangeComplete,
-    onDisabledChange,
 
     // Cross
     allowCross = true,
@@ -222,6 +219,17 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
   // ============================ Range =============================
   const [rangeEnabled, rangeEditable, rangeDraggableTrack, minCount, maxCount] = useRange(range);
+
+  // Check if any handle is disabled - if so, disable all editable operations
+  const hasDisabledHandle = React.useMemo(() => {
+    if (typeof rawDisabled === 'boolean') {
+      return rawDisabled;
+    }
+    return rawDisabled.some((d) => d);
+  }, [rawDisabled]);
+
+  // Disable editable when any handle is disabled
+  const effectiveRangeEditable = rangeEditable && !hasDisabledHandle;
 
   const mergedMin = React.useMemo(() => (isFinite(min) ? min : 0), [min]);
   const mergedMax = React.useMemo(() => (isFinite(max) ? max : 100), [max]);
@@ -321,25 +329,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     // Order first
     const cloneNextValues = [...nextValues].sort((a, b) => a - b);
 
-    // Sync disabled array when values length changes (add/remove handles in editable mode)
-    if (
-      Array.isArray(rawDisabled) &&
-      cloneNextValues.length !== rawValues.length
-    ) {
-      const newDisabled = [...rawDisabled];
-
-      if (cloneNextValues.length > rawValues.length) {
-        const index = cloneNextValues.findIndex((item, i) => item !== rawValues[i]);
-        const insertIndex = index === -1 ? rawValues.length : index;
-        newDisabled.splice(insertIndex, 0, false);
-      } else if (cloneNextValues.length < rawValues.length) {
-        const index = rawValues.findIndex((item, i) => item !== cloneNextValues[i]);
-        newDisabled.splice(index, 1);
-      }
-
-      onDisabledChange?.(newDisabled);
-    }
-
     // Trigger event if needed
     if (onChange && !isEqual(cloneNextValues, rawValues, true)) {
       onChange(getTriggerValue(cloneNextValues));
@@ -365,7 +354,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   });
 
   const onDelete = (index: number) => {
-    if (disabled || !rangeEditable || rawValues.length <= minCount || isHandleDisabled(index)) {
+    if (disabled || !effectiveRangeEditable || rawValues.length <= minCount || isHandleDisabled(index)) {
       return;
     }
 
@@ -390,7 +379,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     triggerChange,
     finishChange,
     offsetValues,
-    rangeEditable,
+    effectiveRangeEditable,
     minCount,
     isHandleDisabled,
   );
@@ -422,14 +411,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
       let focusIndex = valueIndex;
 
-      if (rangeEditable && valueDist !== 0 && (!maxCount || rawValues.length < maxCount)) {
-        const leftDisabled = isHandleDisabled(valueBeforeIndex);
-        const rightDisabled = isHandleDisabled(valueBeforeIndex + 1);
-
-        if (leftDisabled && rightDisabled) {
-          return;
-        }
-
+      if (effectiveRangeEditable && valueDist !== 0 && (!maxCount || rawValues.length < maxCount)) {
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
@@ -716,7 +698,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
           handleRender={handleRender}
           activeHandleRender={activeHandleRender}
           onChangeComplete={finishChange}
-          onDelete={rangeEditable ? onDelete : undefined}
+          onDelete={effectiveRangeEditable ? onDelete : undefined}
         />
 
         <Marks prefixCls={prefixCls} marks={markList} onClick={changeToCloseValue} />

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -78,6 +78,8 @@ export interface SliderProps<ValueType = number | number[]> {
   /** @deprecated Use `onChangeComplete` instead */
   onAfterChange?: (value: ValueType) => void;
   onChangeComplete?: (value: ValueType) => void;
+  /** Callback when disabled array needs to be updated (e.g., when handles are added/removed in editable mode) */
+  onDisabledChange?: (disabled: boolean[]) => void;
 
   // Cross
   allowCross?: boolean;
@@ -149,6 +151,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
     onBeforeChange,
     onAfterChange,
     onChangeComplete,
+    onDisabledChange,
 
     // Cross
     allowCross = true,
@@ -191,9 +194,12 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   const disabled = React.useMemo(() => {
     if (typeof rawDisabled === 'boolean') {
       return rawDisabled;
-    };
+    }
+    if (Array.isArray(value)) {
+      return value.every((_, index) => rawDisabled[index]);
+    }
 
-    return Array.isArray(value) && value.length === rawDisabled.length && rawDisabled.every(Boolean);
+    return false;
   }, [rawDisabled, value]);
 
   const isHandleDisabled = React.useCallback(
@@ -314,6 +320,25 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   const triggerChange = useEvent((nextValues: number[]) => {
     // Order first
     const cloneNextValues = [...nextValues].sort((a, b) => a - b);
+
+    // Sync disabled array when values length changes (add/remove handles in editable mode)
+    if (
+      typeof rawDisabled !== 'boolean' &&
+      Array.isArray(rawDisabled) &&
+      cloneNextValues.length !== rawValues.length
+    ) {
+      const newDisabled = [...rawDisabled];
+
+      if (cloneNextValues.length > rawValues.length) {
+        const index = cloneNextValues.findIndex((item) => !rawValues.includes(item));
+        newDisabled.splice(index, 0, false);
+      } else if (cloneNextValues.length < rawValues.length) {
+        const index = rawValues.findIndex((item) => !cloneNextValues.includes(item));
+        newDisabled.splice(index, 1);
+      }
+
+      onDisabledChange?.(newDisabled);
+    }
 
     // Trigger event if needed
     if (onChange && !isEqual(cloneNextValues, rawValues, true)) {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -424,7 +424,11 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
           }
         }
 
-        cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
+        if (minBound <= maxBound) {
+          cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
+        } else {
+          cloneNextValues[valueIndex] = rawValues[valueIndex];
+        }
         focusIndex = valueIndex;
       }
 

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -205,9 +205,10 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       if (typeof rawDisabled === 'boolean') {
         return rawDisabled;
       }
-      return rawDisabled[index] || false;
+      // Return individual disabled state if defined, otherwise fallback to global disabled
+      return rawDisabled[index] ?? disabled;
     },
-    [rawDisabled],
+    [rawDisabled, disabled],
   );
 
   const direction = React.useMemo<Direction>(() => {
@@ -415,46 +416,35 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
+        // Find nearest enabled handle if current is disabled
         if (isHandleDisabled(valueIndex)) {
-          let nearestIndex = -1;
-          let nearestDist = mergedMax - mergedMin;
+          const enabledIndices = rawValues
+            .map((_, i) => i)
+            .filter((i) => !isHandleDisabled(i));
 
-          rawValues.forEach((val, index) => {
-            if (!isHandleDisabled(index)) {
-              const dist = Math.abs(newValue - val);
-              if (dist < nearestDist) {
-                nearestDist = dist;
-                nearestIndex = index;
-              }
-            }
-          });
+          if (enabledIndices.length === 0) return;
 
-          // If all handles are disabled, do nothing
-          if (nearestIndex === -1) {
-            return;
-          }
-
-          valueIndex = nearestIndex;
+          valueIndex = enabledIndices.reduce((nearest, i) =>
+            Math.abs(newValue - rawValues[i]) < Math.abs(newValue - rawValues[nearest]) ? i : nearest,
+          );
         }
 
-        // Apply boundary constraints from disabled handles
-        let minBound = mergedMin;
-        let maxBound = mergedMax;
-
-        for (let i = valueIndex - 1; i >= 0; i -= 1) {
-          if (isHandleDisabled(i)) {
-            const pushDistance = typeof mergedPush === 'number' ? mergedPush : 0;
-            minBound = rawValues[i] + pushDistance;
-            break;
-          }
-        }
-        for (let i = valueIndex + 1; i < rawValues.length; i += 1) {
-          if (isHandleDisabled(i)) {
-            const pushDistance = typeof mergedPush === 'number' ? mergedPush : 0;
-            maxBound = rawValues[i] - pushDistance;
-            break;
-          }
-        }
+        // Calculate boundaries from disabled handles (treat as fixed anchors)
+        const pushDist = typeof mergedPush === 'number' ? mergedPush : 0;
+        const minBound = Math.max(
+          mergedMin,
+          ...rawValues
+            .slice(0, valueIndex)
+            .map((v, i) => (isHandleDisabled(i) ? v + pushDist : mergedMin))
+            .filter((v) => v > mergedMin),
+        );
+        const maxBound = Math.min(
+          mergedMax,
+          ...rawValues
+            .slice(valueIndex + 1)
+            .map((v, i) => (isHandleDisabled(i + valueIndex + 1) ? v - pushDist : mergedMax))
+            .filter((v) => v < mergedMax),
+        );
 
         cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
         focusIndex = valueIndex;

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -405,20 +405,24 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
         // Calculate boundaries from disabled handles (treat as fixed anchors)
         const pushDist = typeof mergedPush === 'number' ? mergedPush : 0;
-        const minBound = Math.max(
-          mergedMin,
-          ...rawValues
-            .slice(0, valueIndex)
-            .map((v, i) => (isHandleDisabled(i) ? v + pushDist : mergedMin))
-            .filter((v) => v > mergedMin),
-        );
-        const maxBound = Math.min(
-          mergedMax,
-          ...rawValues
-            .slice(valueIndex + 1)
-            .map((v, i) => (isHandleDisabled(i + valueIndex + 1) ? v - pushDist : mergedMax))
-            .filter((v) => v < mergedMax),
-        );
+        let minBound = mergedMin;
+        let maxBound = mergedMax;
+
+        // Find nearest disabled handle on the left as min boundary
+        for (let i = valueIndex - 1; i >= 0; i -= 1) {
+          if (isHandleDisabled(i)) {
+            minBound = Math.max(minBound, rawValues[i] + pushDist);
+            break;
+          }
+        }
+
+        // Find nearest disabled handle on the right as max boundary
+        for (let i = valueIndex + 1; i < rawValues.length; i += 1) {
+          if (isHandleDisabled(i)) {
+            maxBound = Math.min(maxBound, rawValues[i] - pushDist);
+            break;
+          }
+        }
 
         cloneNextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, newValue));
         focusIndex = valueIndex;

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -461,13 +461,15 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
         for (let i = valueIndex - 1; i >= 0; i -= 1) {
           if (isHandleDisabled(i)) {
-            minBound = rawValues[i];
+            const pushDistance = typeof mergedPush === 'number' ? mergedPush : 0;
+            minBound = rawValues[i] + pushDistance;
             break;
           }
         }
         for (let i = valueIndex + 1; i < rawValues.length; i += 1) {
           if (isHandleDisabled(i)) {
-            maxBound = rawValues[i];
+            const pushDistance = typeof mergedPush === 'number' ? mergedPush : 0;
+            maxBound = rawValues[i] - pushDistance;
             break;
           }
         }

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -199,8 +199,6 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
   // ============================ Range =============================
   const [rangeEnabled, rangeEditable, rangeDraggableTrack, minCount, maxCount] = useRange(range);
 
-
-
   const mergedMin = React.useMemo(() => (isFinite(min) ? min : 0), [min]);
   const mergedMax = React.useMemo(() => (isFinite(max) ? max : 100), [max]);
 

--- a/src/Tracks/index.tsx
+++ b/src/Tracks/index.tsx
@@ -14,8 +14,18 @@ export interface TrackProps {
 }
 
 const Tracks: React.FC<TrackProps> = (props) => {
-  const { prefixCls, style, values, startPoint, onStartMove } = props;
-  const { included, range, min, styles, classNames } = React.useContext(SliderContext);
+  const { prefixCls, style, values, startPoint, onStartMove: propsOnStartMove } = props;
+  const { included, range, min, styles, classNames, isHandleDisabled } = React.useContext(SliderContext);
+
+  const hasDisabledHandle = React.useMemo(() => {
+    if (!isHandleDisabled) return false;
+    for (let i = 0; i < values.length; i++) {
+      if (isHandleDisabled(i)) return true;
+    }
+    return false;
+  }, [isHandleDisabled, values.length]);
+
+  const onStartMove = hasDisabledHandle ? undefined : propsOnStartMove;
 
   // =========================== List ===========================
   const trackList = React.useMemo(() => {

--- a/src/Tracks/index.tsx
+++ b/src/Tracks/index.tsx
@@ -17,12 +17,10 @@ const Tracks: React.FC<TrackProps> = (props) => {
   const { prefixCls, style, values, startPoint, onStartMove: propsOnStartMove } = props;
   const { included, range, min, styles, classNames, isHandleDisabled } = React.useContext(SliderContext);
 
-  const hasDisabledHandle = React.useMemo(() => {
-    for (let i = 0; i < values.length; i++) {
-      if (isHandleDisabled(i)) return true;
-    }
-    return false;
-  }, [isHandleDisabled, values.length]);
+  const hasDisabledHandle = React.useMemo(
+    () => values.some((_, index) => isHandleDisabled(index)),
+    [isHandleDisabled, values],
+  );
 
   const onStartMove = hasDisabledHandle ? undefined : propsOnStartMove;
 

--- a/src/Tracks/index.tsx
+++ b/src/Tracks/index.tsx
@@ -18,7 +18,6 @@ const Tracks: React.FC<TrackProps> = (props) => {
   const { included, range, min, styles, classNames, isHandleDisabled } = React.useContext(SliderContext);
 
   const hasDisabledHandle = React.useMemo(() => {
-    if (!isHandleDisabled) return false;
     for (let i = 0; i < values.length; i++) {
       if (isHandleDisabled(i)) return true;
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -33,6 +33,7 @@ const SliderContext = React.createContext<SliderContextProps>({
   keyboard: true,
   styles: {},
   classNames: {},
+  isHandleDisabled: () => false,
 });
 
 export default SliderContext;

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ export interface SliderContextProps {
   ariaValueTextFormatterForHandle?: AriaValueFormat | AriaValueFormat[];
   classNames: SliderClassNames;
   styles: SliderStyles;
-  isHandleDisabled?: (index: number) => boolean;
+  isHandleDisabled: (index: number) => boolean;
 }
 
 const SliderContext = React.createContext<SliderContextProps>({

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,6 +19,7 @@ export interface SliderContextProps {
   ariaValueTextFormatterForHandle?: AriaValueFormat | AriaValueFormat[];
   classNames: SliderClassNames;
   styles: SliderStyles;
+  isHandleDisabled?: (index: number) => boolean;
 }
 
 const SliderContext = React.createContext<SliderContextProps>({

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -2,24 +2,19 @@ import * as React from 'react';
 
 const useDisabled = (
   rawDisabled: boolean | boolean[],
-  mergedValue?: number | number[],
+  rawValue: number[],
 ): [boolean, boolean] => {
-
-  const values = React.useMemo(
-    () => (Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
-    [mergedValue],
-  );
 
   const disabledArray = React.useMemo(() => {
     if (typeof rawDisabled === 'boolean') {
-      return values.map(() => rawDisabled);
+      return rawValue.map(() => rawDisabled);
     }
-    return Array.isArray(rawDisabled) ? rawDisabled : values.map(() => false);
-  }, [rawDisabled, mergedValue]);
+    return Array.isArray(rawDisabled) ? rawDisabled : rawValue.map(() => false);
+  }, [rawDisabled, rawValue]);
 
   const disabled = React.useMemo(() => {
-    return values.every((_, index) => disabledArray[index]);
-  }, [disabledArray, values]);
+    return rawValue.every((_, index) => disabledArray[index]);
+  }, [disabledArray, rawValue]);
 
   const hasDisabledHandle = React.useMemo(() => {
     return disabledArray.some((d) => d);

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 const useDisabled = (
   rawDisabled: boolean | boolean[],
   mergedValue?: number | number[],
-): [boolean, (index: number) => boolean, boolean] => {
+): [boolean, boolean] => {
 
   const values = React.useMemo(
     () => (Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
@@ -21,20 +21,12 @@ const useDisabled = (
     return values.every((_, index) => disabledArray[index]);
   }, [disabledArray, values]);
 
-  const isHandleDisabled = React.useCallback(
-    (index: number): boolean => {
-      return disabledArray[index] ?? disabled;
-    },
-    [disabledArray, disabled],
-  );
-
   const hasDisabledHandle = React.useMemo(() => {
     return disabledArray.some((d) => d);
   }, [disabledArray]);
 
   return [
     disabled,
-    isHandleDisabled,
     hasDisabledHandle,
   ];
 };

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -2,9 +2,11 @@ import * as React from 'react';
 
 const useDisabled = (
   rawDisabled: boolean | boolean[],
+  rawValues: number[],
 ): [
   isHandleDisabled: (index: number) => boolean,
-  getDisabledState: (rawValues: number[]) => [disabled: boolean, hasDisabledHandle: boolean],
+  disabled: boolean,
+  hasDisabledHandle: boolean,
 ] => {
   const isHandleDisabled = React.useCallback(
     (index: number) => {
@@ -17,8 +19,10 @@ const useDisabled = (
     [rawDisabled],
   );
 
-  const getDisabledState = React.useCallback(
-    (rawValues: number[]): [disabled: boolean, hasDisabledHandle: boolean] => {
+  const [disabled, hasDisabledHandle] = React.useMemo<
+    [disabled: boolean, hasDisabledHandle: boolean]
+  >(
+    () => {
       if (typeof rawDisabled === 'boolean') {
         return [rawDisabled, rawDisabled && rawValues.length > 0];
       }
@@ -28,12 +32,13 @@ const useDisabled = (
         rawValues.some((_, index) => isHandleDisabled(index)),
       ];
     },
-    [rawDisabled, isHandleDisabled],
+    [rawDisabled, rawValues, isHandleDisabled],
   );
 
-  return React.useMemo(() => [isHandleDisabled, getDisabledState], [
+  return React.useMemo(() => [isHandleDisabled, disabled, hasDisabledHandle], [
     isHandleDisabled,
-    getDisabledState,
+    disabled,
+    hasDisabledHandle,
   ]);
 };
 

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -2,18 +2,39 @@ import * as React from 'react';
 
 const useDisabled = (
   rawDisabled: boolean | boolean[],
-  rawValues: number[],
-): [disabled: boolean, hasDisabledHandle: boolean] => {
-  return React.useMemo(() => {
-    if (typeof rawDisabled === 'boolean') {
-      return [rawDisabled, rawDisabled && rawValues.length > 0];
-    }
+): [
+  isHandleDisabled: (index: number) => boolean,
+  getDisabledState: (rawValues: number[]) => [disabled: boolean, hasDisabledHandle: boolean],
+] => {
+  const isHandleDisabled = React.useCallback(
+    (index: number) => {
+      if (typeof rawDisabled === 'boolean') {
+        return rawDisabled;
+      }
 
-    return [
-      rawValues.length > 0 && rawValues.every((_, index) => rawDisabled[index]),
-      rawValues.some((_, index) => rawDisabled[index]),
-    ];
-  }, [rawDisabled, rawValues]);
+      return rawDisabled[index] ?? false;
+    },
+    [rawDisabled],
+  );
+
+  const getDisabledState = React.useCallback(
+    (rawValues: number[]): [disabled: boolean, hasDisabledHandle: boolean] => {
+      if (typeof rawDisabled === 'boolean') {
+        return [rawDisabled, rawDisabled && rawValues.length > 0];
+      }
+
+      return [
+        rawValues.length > 0 && rawValues.every((_, index) => isHandleDisabled(index)),
+        rawValues.some((_, index) => isHandleDisabled(index)),
+      ];
+    },
+    [rawDisabled, isHandleDisabled],
+  );
+
+  return React.useMemo(() => [isHandleDisabled, getDisabledState], [
+    isHandleDisabled,
+    getDisabledState,
+  ]);
 };
 
 export default useDisabled;

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -2,28 +2,18 @@ import * as React from 'react';
 
 const useDisabled = (
   rawDisabled: boolean | boolean[],
-  rawValue: number[],
+  rawValues: number[],
 ): [boolean, boolean] => {
-
-  const disabledArray = React.useMemo(() => {
+  return React.useMemo(() => {
     if (typeof rawDisabled === 'boolean') {
-      return rawValue.map(() => rawDisabled);
+      return [rawDisabled, rawDisabled && rawValues.length > 0];
     }
-    return Array.isArray(rawDisabled) ? rawDisabled : rawValue.map(() => false);
-  }, [rawDisabled, rawValue]);
 
-  const disabled = React.useMemo(() => {
-    return rawValue.length > 0 && rawValue.every((_, index) => disabledArray[index]);
-  }, [disabledArray, rawValue]);
-
-  const hasDisabledHandle = React.useMemo(() => {
-    return disabledArray.some((d) => d);
-  }, [disabledArray]);
-
-  return [
-    disabled,
-    hasDisabledHandle,
-  ];
+    return [
+      rawValues.length > 0 && rawValues.every((_, index) => rawDisabled[index]),
+      rawValues.some((_, index) => rawDisabled[index]),
+    ];
+  }, [rawDisabled, rawValues]);
 };
 
 export default useDisabled;

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -5,36 +5,32 @@ const useDisabled = (
   mergedValue?: number | number[],
 ): [boolean, (index: number) => boolean, boolean] => {
 
-  const disabledIsArray = Array.isArray(rawDisabled);
-  const disabledIsBoolean = typeof rawDisabled === 'boolean';
   const values = React.useMemo(
     () => (Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
     [mergedValue],
   );
 
-  const disabled = React.useMemo(() => {
-    if (disabledIsBoolean) {
-      return rawDisabled;
+  const disabledArray = React.useMemo(() => {
+    if (typeof rawDisabled === 'boolean') {
+      return values.map(() => rawDisabled);
     }
-    return disabledIsArray ? values.every((_, index) => rawDisabled[index]) : false;
+    return Array.isArray(rawDisabled) ? rawDisabled : values.map(() => false);
   }, [rawDisabled, mergedValue]);
+
+  const disabled = React.useMemo(() => {
+    return values.every((_, index) => disabledArray[index]);
+  }, [disabledArray, values]);
 
   const isHandleDisabled = React.useCallback(
     (index: number): boolean => {
-      if (disabledIsBoolean) {
-        return rawDisabled;
-      }
-      return rawDisabled[index] ?? disabled;
+      return disabledArray[index] ?? disabled;
     },
-    [rawDisabled, disabled],
+    [disabledArray, disabled],
   );
 
   const hasDisabledHandle = React.useMemo(() => {
-    if (disabledIsBoolean) {
-      return rawDisabled;
-    }
-    return rawDisabled.some((d) => d);
-  }, [rawDisabled]);
+    return disabledArray.some((d) => d);
+  }, [disabledArray]);
 
   return [
     disabled,

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 const useDisabled = (
   rawDisabled: boolean | boolean[],
   rawValues: number[],
-): [boolean, boolean] => {
+): [disabled: boolean, hasDisabledHandle: boolean] => {
   return React.useMemo(() => {
     if (typeof rawDisabled === 'boolean') {
       return [rawDisabled, rawDisabled && rawValues.length > 0];

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+const useDisabled = (
+  rawDisabled: boolean | boolean[],
+  mergedValue?: number | number[],
+): [boolean, (index: number) => boolean, boolean] => {
+
+  const disabledIsArray = Array.isArray(rawDisabled);
+  const disabledIsBoolean = typeof rawDisabled === 'boolean';
+  const values = React.useMemo(
+    () => (Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
+    [mergedValue],
+  );
+
+  const disabled = React.useMemo(() => {
+    if (disabledIsBoolean) {
+      return rawDisabled;
+    }
+    return disabledIsArray ? values.every((_, index) => rawDisabled[index]) : false;
+  }, [rawDisabled, mergedValue]);
+
+  const isHandleDisabled = React.useCallback(
+    (index: number): boolean => {
+      if (disabledIsBoolean) {
+        return rawDisabled;
+      }
+      return rawDisabled[index] ?? disabled;
+    },
+    [rawDisabled, disabled],
+  );
+
+  const hasDisabledHandle = React.useMemo(() => {
+    if (disabledIsBoolean) {
+      return rawDisabled;
+    }
+    return rawDisabled.some((d) => d);
+  }, [rawDisabled]);
+
+  return [
+    disabled,
+    isHandleDisabled,
+    hasDisabledHandle,
+  ];
+};
+
+export default useDisabled;

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -13,7 +13,7 @@ const useDisabled = (
   }, [rawDisabled, rawValue]);
 
   const disabled = React.useMemo(() => {
-    return rawValue.every((_, index) => disabledArray[index]);
+    return rawValue.length > 0 && rawValue.every((_, index) => disabledArray[index]);
   }, [disabledArray, rawValue]);
 
   const hasDisabledHandle = React.useMemo(() => {

--- a/src/hooks/useDisabled.ts
+++ b/src/hooks/useDisabled.ts
@@ -2,11 +2,9 @@ import * as React from 'react';
 
 const useDisabled = (
   rawDisabled: boolean | boolean[],
-  rawValues: number[],
 ): [
   isHandleDisabled: (index: number) => boolean,
-  disabled: boolean,
-  hasDisabledHandle: boolean,
+  getDisabledState: (rawValues: number[]) => [disabled: boolean, hasDisabledHandle: boolean],
 ] => {
   const isHandleDisabled = React.useCallback(
     (index: number) => {
@@ -19,10 +17,8 @@ const useDisabled = (
     [rawDisabled],
   );
 
-  const [disabled, hasDisabledHandle] = React.useMemo<
-    [disabled: boolean, hasDisabledHandle: boolean]
-  >(
-    () => {
+  const getDisabledState = React.useCallback(
+    (rawValues: number[]): [disabled: boolean, hasDisabledHandle: boolean] => {
       if (typeof rawDisabled === 'boolean') {
         return [rawDisabled, rawDisabled && rawValues.length > 0];
       }
@@ -32,13 +28,12 @@ const useDisabled = (
         rawValues.some((_, index) => isHandleDisabled(index)),
       ];
     },
-    [rawDisabled, rawValues, isHandleDisabled],
+    [rawDisabled, isHandleDisabled],
   );
 
-  return React.useMemo(() => [isHandleDisabled, disabled, hasDisabledHandle], [
+  return React.useMemo(() => [isHandleDisabled, getDisabledState], [
     isHandleDisabled,
-    disabled,
-    hasDisabledHandle,
+    getDisabledState,
   ]);
 };
 

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -26,7 +26,7 @@ function useDrag(
   offsetValues: OffsetValues,
   editable: boolean,
   minCount: number,
-  isHandleDisabled?: (index: number) => boolean,
+  isHandleDisabled: (index: number) => boolean,
 ): [
   draggingIndex: number,
   draggingValue: number,
@@ -94,7 +94,7 @@ function useDrag(
       if (valueIndex === -1) {
         // >>>> Dragging on the track
         // Defensive: should not happen as Tracks/index.tsx blocks this when any handle is disabled
-        if (isHandleDisabled && originValues.some((_, index) => isHandleDisabled(index))) {
+        if (originValues.some((_, index) => isHandleDisabled(index))) {
           return;
         }
 
@@ -133,7 +133,7 @@ function useDrag(
 
     const initialValues = startValues || rawValues;
     // Defensive: should not happen as Handle.tsx blocks this when handle is disabled
-    if (isHandleDisabled && isHandleDisabled(valueIndex)) {
+    if (isHandleDisabled(valueIndex)) {
       return;
     }
 

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -26,6 +26,7 @@ function useDrag(
   offsetValues: OffsetValues,
   editable: boolean,
   minCount: number,
+  isHandleDisabled?: (index: number) => boolean,
 ): [
   draggingIndex: number,
   draggingValue: number,
@@ -77,6 +78,7 @@ function useDrag(
     }
     triggerChange(changeValues);
 
+    // Optional callback for drag change (not used in current implementation)
     if (onDragChange) {
       onDragChange({
         rawValues: nextValues,
@@ -91,6 +93,11 @@ function useDrag(
     (valueIndex: number, offsetPercent: number, deleteMark: boolean) => {
       if (valueIndex === -1) {
         // >>>> Dragging on the track
+        // Defensive: should not happen as Tracks/index.tsx blocks this when any handle is disabled
+        if (isHandleDisabled && originValues.some((_, index) => isHandleDisabled(index))) {
+          return;
+        }
+
         const startValue = originValues[0];
         const endValue = originValues[originValues.length - 1];
         const maxStartOffset = min - startValue;
@@ -124,8 +131,12 @@ function useDrag(
   const onStartMove: OnStartMove = (e, valueIndex, startValues?: number[]) => {
     e.stopPropagation();
 
-    // 如果是点击 track 触发的，需要传入变化后的初始值，而不能直接用 rawValues
     const initialValues = startValues || rawValues;
+    // Defensive: should not happen as Handle.tsx blocks this when handle is disabled
+    if (isHandleDisabled && isHandleDisabled(valueIndex)) {
+      return;
+    }
+
     const originValue = initialValues[valueIndex];
 
     setDraggingIndex(valueIndex);
@@ -139,7 +150,7 @@ function useDrag(
     // We declare it here since closure can't get outer latest value
     let deleteMark = false;
 
-    // Internal trigger event
+    // Optional callback for drag start (not used in current implementation)
     if (onDragStart) {
       onDragStart({
         rawValues: initialValues,

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -190,24 +190,32 @@ export default function useOffset(
     return (pushable === null && dist === 0) || (typeof pushable === 'number' && dist < pushable);
   };
 
-  // Get the minimum boundary for a handle considering disabled handles
+  // Get the minimum boundary for a handle considering disabled handles as fixed anchors
   const getHandleMinBound = (values: number[], handleIndex: number): number => {
+    const gap = typeof pushable === 'number' ? pushable : 0;
+    // Collect min and all left-side disabled handle positions as candidates
+    const candidates = [min];
     for (let i = handleIndex - 1; i >= 0; i -= 1) {
       if (isHandleDisabled(i)) {
-        return values[i] + (typeof pushable === 'number' ? pushable : 0);
+        candidates.push(values[i] + gap);
+        break; // Only need the nearest disabled handle
       }
     }
-    return min;
+    return Math.max(...candidates);
   };
 
-  // Get the maximum boundary for a handle considering disabled handles
+  // Get the maximum boundary for a handle considering disabled handles as fixed anchors
   const getHandleMaxBound = (values: number[], handleIndex: number): number => {
+    const gap = typeof pushable === 'number' ? pushable : 0;
+    // Collect max and all right-side disabled handle positions as candidates
+    const candidates = [max];
     for (let i = handleIndex + 1; i < values.length; i += 1) {
       if (isHandleDisabled(i)) {
-        return values[i] - (typeof pushable === 'number' ? pushable : 0);
+        candidates.push(values[i] - gap);
+        break; // Only need the nearest disabled handle
       }
     }
-    return max;
+    return Math.min(...candidates);
   };
 
   // Values
@@ -222,7 +230,13 @@ export default function useOffset(
     nextValues[valueIndex] = nextValue;
 
     // Apply disabled handle boundaries
-    nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
+    // If bounds conflict (min > max), the handle is locked between two disabled handles
+    // In this case, keep the original value
+    if (minBound <= maxBound) {
+      nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
+    } else {
+      nextValues[valueIndex] = originValue;
+    }
 
     if (allowCross === false) {
       // >>>>> Allow Cross

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -36,7 +36,7 @@ export default function useOffset(
   markList: InternalMarkObj[],
   allowCross: boolean,
   pushable: false | number,
-  isHandleDisabled?: (index: number) => boolean,
+  isHandleDisabled: (index: number) => boolean,
 ): [FormatValue, OffsetValues] {
   const formatRangeValue: FormatRangeValue = React.useCallback(
     (val) => Math.max(min, Math.min(max, val)),
@@ -192,7 +192,6 @@ export default function useOffset(
 
   // Get the minimum boundary for a handle considering disabled handles
   const getHandleMinBound = (values: number[], handleIndex: number): number => {
-    if (!isHandleDisabled) return min;
     for (let i = handleIndex - 1; i >= 0; i -= 1) {
       if (isHandleDisabled(i)) {
         return values[i] + (typeof pushable === 'number' ? pushable : 0);
@@ -203,7 +202,6 @@ export default function useOffset(
 
   // Get the maximum boundary for a handle considering disabled handles
   const getHandleMaxBound = (values: number[], handleIndex: number): number => {
-    if (!isHandleDisabled) return max;
     for (let i = handleIndex + 1; i < values.length; i += 1) {
       if (isHandleDisabled(i)) {
         return values[i] - (typeof pushable === 'number' ? pushable : 0);
@@ -224,9 +222,7 @@ export default function useOffset(
     nextValues[valueIndex] = nextValue;
 
     // Apply disabled handle boundaries
-    if (isHandleDisabled) {
-      nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
-    }
+    nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
 
     if (allowCross === false) {
       // >>>>> Allow Cross
@@ -253,7 +249,7 @@ export default function useOffset(
       // >>>>>> Basic push
       // End values (skip disabled handles)
       for (let i = valueIndex + 1; i < nextValues.length; i += 1) {
-        if (isHandleDisabled?.(i)) {
+        if (isHandleDisabled(i)) {
           break; // Stop pushing when hitting a disabled handle
         }
         let changed = true;
@@ -261,14 +257,12 @@ export default function useOffset(
           ({ value: nextValues[i], changed } = offsetChangedValue(nextValues, 1, i));
         }
         // Apply boundary constraint to pushed handle
-        if (isHandleDisabled) {
-          nextValues[i] = Math.min(nextValues[i], getHandleMaxBound(nextValues, i));
-        }
+        nextValues[i] = Math.min(nextValues[i], getHandleMaxBound(nextValues, i));
       }
 
       // Start values (skip disabled handles)
       for (let i = valueIndex; i > 0; i -= 1) {
-        if (isHandleDisabled?.(i - 1)) {
+        if (isHandleDisabled(i - 1)) {
           break; // Stop pushing when hitting a disabled handle
         }
         let changed = true;
@@ -276,15 +270,13 @@ export default function useOffset(
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
         // Apply boundary constraint to pushed handle
-        if (isHandleDisabled) {
-          nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
-        }
+        nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
       }
 
       // >>>>> Revert back to safe push range
       // End to Start (skip disabled handles)
       for (let i = nextValues.length - 1; i > 0; i -= 1) {
-        if (isHandleDisabled?.(i) || isHandleDisabled?.(i - 1)) {
+        if (isHandleDisabled(i) || isHandleDisabled(i - 1)) {
           continue; // Skip if either handle is disabled
         }
         let changed = true;
@@ -292,14 +284,12 @@ export default function useOffset(
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
         // Apply boundary constraint to pushed handle
-        if (isHandleDisabled) {
-          nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
-        }
+        nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
       }
 
       // Start to End (skip disabled handles)
       for (let i = 0; i < nextValues.length - 1; i += 1) {
-        if (isHandleDisabled?.(i) || isHandleDisabled?.(i + 1)) {
+        if (isHandleDisabled(i) || isHandleDisabled(i + 1)) {
           continue; // Skip if either handle is disabled
         }
         let changed = true;
@@ -307,9 +297,7 @@ export default function useOffset(
           ({ value: nextValues[i + 1], changed } = offsetChangedValue(nextValues, 1, i + 1));
         }
         // Apply boundary constraint to pushed handle
-        if (isHandleDisabled) {
-          nextValues[i + 1] = Math.min(nextValues[i + 1], getHandleMaxBound(nextValues, i + 1));
-        }
+        nextValues[i + 1] = Math.min(nextValues[i + 1], getHandleMaxBound(nextValues, i + 1));
       }
     }
 

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -106,12 +106,15 @@ export const getClosestEnabledHandleIndex = (
   return closestIndex;
 };
 
-export function useFormatValue(
+export default function useOffset(
   min: number,
   max: number,
   step: number,
   markList: InternalMarkObj[],
-): FormatValue {
+  allowCross: boolean,
+  pushable: false | number,
+  isHandleDisabled: IsHandleDisabled,
+): [FormatValue, OffsetValues] {
   const formatRangeValue: FormatRangeValue = React.useCallback(
     (val) => Math.max(min, Math.min(max, val)),
     [min, max],
@@ -162,37 +165,6 @@ export function useFormatValue(
       return closeValue;
     },
     [min, max, markList, step, formatRangeValue, formatStepValue],
-  );
-
-  return formatValue;
-}
-
-export default function useOffset(
-  min: number,
-  max: number,
-  step: number,
-  markList: InternalMarkObj[],
-  allowCross: boolean,
-  pushable: false | number,
-  formatValue: FormatValue,
-  isHandleDisabled: IsHandleDisabled,
-): OffsetValues {
-  const formatStepValue: FormatStepValue = React.useCallback(
-    (val) => {
-      if (step !== null) {
-        const rangedValue = Math.max(min, Math.min(max, val));
-        const stepValue = min + Math.round((rangedValue - min) / step) * step;
-
-        // Cut number in case to be like 0.30000000000000004
-        const getDecimal = (num: number) => (String(num).split('.')[1] || '').length;
-        const maxDecimal = Math.max(getDecimal(step), getDecimal(max), getDecimal(min));
-        const fixedValue = Number(stepValue.toFixed(maxDecimal));
-
-        return min <= fixedValue && fixedValue <= max ? fixedValue : null!;
-      }
-      return null!;
-    },
-    [step, min, max],
   );
 
   // ========================== Offset ==========================
@@ -432,5 +404,5 @@ export default function useOffset(
     };
   };
 
-  return offsetValues;
+  return [formatValue, offsetValues];
 }

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -244,16 +244,22 @@ export default function useOffset(
       // =============== Push ==================
 
       // >>>>>> Basic push
-      // End values
+      // End values (skip disabled handles)
       for (let i = valueIndex + 1; i < nextValues.length; i += 1) {
+        if (isHandleDisabled?.(i)) {
+          break; // Stop pushing when hitting a disabled handle
+        }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i], changed } = offsetChangedValue(nextValues, 1, i));
         }
       }
 
-      // Start values
+      // Start values (skip disabled handles)
       for (let i = valueIndex; i > 0; i -= 1) {
+        if (isHandleDisabled?.(i - 1)) {
+          break; // Stop pushing when hitting a disabled handle
+        }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
@@ -261,16 +267,22 @@ export default function useOffset(
       }
 
       // >>>>> Revert back to safe push range
-      // End to Start
+      // End to Start (skip disabled handles)
       for (let i = nextValues.length - 1; i > 0; i -= 1) {
+        if (isHandleDisabled?.(i) || isHandleDisabled?.(i - 1)) {
+          continue; // Skip if either handle is disabled
+        }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
       }
 
-      // Start to End
+      // Start to End (skip disabled handles)
       for (let i = 0; i < nextValues.length - 1; i += 1) {
+        if (isHandleDisabled?.(i) || isHandleDisabled?.(i + 1)) {
+          continue; // Skip if either handle is disabled
+        }
         let changed = true;
         while (needPush(nextValues[i + 1] - nextValues[i]) && changed) {
           ({ value: nextValues[i + 1], changed } = offsetChangedValue(nextValues, 1, i + 1));

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -190,28 +190,35 @@ export default function useOffset(
     return (pushable === null && dist === 0) || (typeof pushable === 'number' && dist < pushable);
   };
 
+  // Get the minimum boundary for a handle considering disabled handles
+  const getHandleMinBound = (values: number[], handleIndex: number): number => {
+    if (!isHandleDisabled) return min;
+    for (let i = handleIndex - 1; i >= 0; i -= 1) {
+      if (isHandleDisabled(i)) {
+        return values[i] + (typeof pushable === 'number' ? pushable : 0);
+      }
+    }
+    return min;
+  };
+
+  // Get the maximum boundary for a handle considering disabled handles
+  const getHandleMaxBound = (values: number[], handleIndex: number): number => {
+    if (!isHandleDisabled) return max;
+    for (let i = handleIndex + 1; i < values.length; i += 1) {
+      if (isHandleDisabled(i)) {
+        return values[i] - (typeof pushable === 'number' ? pushable : 0);
+      }
+    }
+    return max;
+  };
+
   // Values
   const offsetValues: OffsetValues = (values, offset, valueIndex, mode = 'unit') => {
     const nextValues = values.map<number>(formatValue);
     const originValue = nextValues[valueIndex];
 
-    let minBound = min;
-    let maxBound = max;
-
-    if (isHandleDisabled) {
-      for (let i = valueIndex - 1; i >= 0; i -= 1) {
-        if (isHandleDisabled(i)) {
-          minBound = nextValues[i];
-          break;
-        }
-      }
-      for (let i = valueIndex + 1; i < nextValues.length; i += 1) {
-        if (isHandleDisabled(i)) {
-          maxBound = nextValues[i];
-          break;
-        }
-      }
-    }
+    const minBound = getHandleMinBound(nextValues, valueIndex);
+    const maxBound = getHandleMaxBound(nextValues, valueIndex);
 
     const nextValue = offsetValue(nextValues, offset, valueIndex, mode);
     nextValues[valueIndex] = nextValue;
@@ -253,6 +260,10 @@ export default function useOffset(
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i], changed } = offsetChangedValue(nextValues, 1, i));
         }
+        // Apply boundary constraint to pushed handle
+        if (isHandleDisabled) {
+          nextValues[i] = Math.min(nextValues[i], getHandleMaxBound(nextValues, i));
+        }
       }
 
       // Start values (skip disabled handles)
@@ -263,6 +274,10 @@ export default function useOffset(
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
+        }
+        // Apply boundary constraint to pushed handle
+        if (isHandleDisabled) {
+          nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
         }
       }
 
@@ -276,6 +291,10 @@ export default function useOffset(
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
+        // Apply boundary constraint to pushed handle
+        if (isHandleDisabled) {
+          nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
+        }
       }
 
       // Start to End (skip disabled handles)
@@ -286,6 +305,10 @@ export default function useOffset(
         let changed = true;
         while (needPush(nextValues[i + 1] - nextValues[i]) && changed) {
           ({ value: nextValues[i + 1], changed } = offsetChangedValue(nextValues, 1, i + 1));
+        }
+        // Apply boundary constraint to pushed handle
+        if (isHandleDisabled) {
+          nextValues[i + 1] = Math.min(nextValues[i + 1], getHandleMaxBound(nextValues, i + 1));
         }
       }
     }

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -36,6 +36,7 @@ export default function useOffset(
   markList: InternalMarkObj[],
   allowCross: boolean,
   pushable: false | number,
+  isHandleDisabled?: (index: number) => boolean,
 ): [FormatValue, OffsetValues] {
   const formatRangeValue: FormatRangeValue = React.useCallback(
     (val) => Math.max(min, Math.min(max, val)),
@@ -193,8 +194,32 @@ export default function useOffset(
   const offsetValues: OffsetValues = (values, offset, valueIndex, mode = 'unit') => {
     const nextValues = values.map<number>(formatValue);
     const originValue = nextValues[valueIndex];
+
+    let minBound = min;
+    let maxBound = max;
+
+    if (isHandleDisabled) {
+      for (let i = valueIndex - 1; i >= 0; i -= 1) {
+        if (isHandleDisabled(i)) {
+          minBound = nextValues[i];
+          break;
+        }
+      }
+      for (let i = valueIndex + 1; i < nextValues.length; i += 1) {
+        if (isHandleDisabled(i)) {
+          maxBound = nextValues[i];
+          break;
+        }
+      }
+    }
+
     const nextValue = offsetValue(nextValues, offset, valueIndex, mode);
     nextValues[valueIndex] = nextValue;
+
+    // Apply disabled handle boundaries
+    if (isHandleDisabled) {
+      nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
+    }
 
     if (allowCross === false) {
       // >>>>> Allow Cross

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -190,9 +190,10 @@ export default function useOffset(
     return (pushable === null && dist === 0) || (typeof pushable === 'number' && dist < pushable);
   };
 
+  const gap = typeof pushable === 'number' ? pushable : 0;
+
   // Get the minimum boundary for a handle considering disabled handles as fixed anchors
   const getHandleMinBound = (values: number[], handleIndex: number): number => {
-    const gap = typeof pushable === 'number' ? pushable : 0;
     // Collect min and all left-side disabled handle positions as candidates
     const candidates = [min];
     for (let i = handleIndex - 1; i >= 0; i -= 1) {
@@ -206,7 +207,6 @@ export default function useOffset(
 
   // Get the maximum boundary for a handle considering disabled handles as fixed anchors
   const getHandleMaxBound = (values: number[], handleIndex: number): number => {
-    const gap = typeof pushable === 'number' ? pushable : 0;
     // Collect max and all right-side disabled handle positions as candidates
     const candidates = [max];
     for (let i = handleIndex + 1; i < values.length; i += 1) {

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -11,6 +11,7 @@ type FormatStepValue = (value: number) => number;
 type FormatValue = (value: number) => number;
 
 type OffsetMode = 'unit' | 'dist';
+type IsHandleDisabled = (index: number) => boolean;
 
 type OffsetValue = (
   values: number[],
@@ -29,6 +30,72 @@ export type OffsetValues = (
   values: number[];
 };
 
+export const getDisabledBoundaryValues = (
+  values: number[],
+  valueIndex: number,
+  min: number,
+  max: number,
+  pushable: false | number,
+  isHandleDisabled: IsHandleDisabled,
+): [number, number] => {
+  const pushGap = typeof pushable === 'number' ? pushable : 0;
+  let minBound = min;
+  let maxBound = max;
+
+  for (let i = valueIndex - 1; i >= 0; i -= 1) {
+    if (isHandleDisabled(i)) {
+      minBound = values[i] + pushGap;
+      break;
+    }
+  }
+
+  for (let i = valueIndex + 1; i < values.length; i += 1) {
+    if (isHandleDisabled(i)) {
+      maxBound = values[i] - pushGap;
+      break;
+    }
+  }
+
+  return [minBound, maxBound];
+};
+
+export const getClosestEnabledHandleIndex = (
+  values: number[],
+  targetValue: number,
+  min: number,
+  max: number,
+  pushable: false | number,
+  isHandleDisabled: IsHandleDisabled,
+) => {
+  let closestIndex = -1;
+  let closestDist = max - min;
+
+  values.forEach((value, index) => {
+    if (isHandleDisabled(index)) {
+      return;
+    }
+
+    const [minBound, maxBound] = getDisabledBoundaryValues(
+      values,
+      index,
+      min,
+      max,
+      pushable,
+      isHandleDisabled,
+    );
+
+    if (minBound <= targetValue && targetValue <= maxBound) {
+      const dist = Math.abs(targetValue - value);
+      if (dist <= closestDist) {
+        closestDist = dist;
+        closestIndex = index;
+      }
+    }
+  });
+
+  return closestIndex;
+};
+
 export default function useOffset(
   min: number,
   max: number,
@@ -36,7 +103,7 @@ export default function useOffset(
   markList: InternalMarkObj[],
   allowCross: boolean,
   pushable: false | number,
-  isHandleDisabled: (index: number) => boolean,
+  isHandleDisabled: IsHandleDisabled,
 ): [FormatValue, OffsetValues] {
   const formatRangeValue: FormatRangeValue = React.useCallback(
     (val) => Math.max(min, Math.min(max, val)),
@@ -193,48 +260,23 @@ export default function useOffset(
     return (pushable === null && dist === 0) || (typeof pushable === 'number' && dist < pushable);
   };
 
-  const gap = typeof pushable === 'number' ? pushable : 0;
-
-  // Get the minimum boundary for a handle considering disabled handles as fixed anchors
-  const getHandleMinBound = (values: number[], handleIndex: number): number => {
-    // Collect min and all left-side disabled handle positions as candidates
-    const candidates = [min];
-    for (let i = handleIndex - 1; i >= 0; i -= 1) {
-      if (isHandleDisabled(i)) {
-        candidates.push(values[i] + gap);
-        break; // Only need the nearest disabled handle
-      }
-    }
-    return Math.max(...candidates);
-  };
-
-  // Get the maximum boundary for a handle considering disabled handles as fixed anchors
-  const getHandleMaxBound = (values: number[], handleIndex: number): number => {
-    // Collect max and all right-side disabled handle positions as candidates
-    const candidates = [max];
-    for (let i = handleIndex + 1; i < values.length; i += 1) {
-      if (isHandleDisabled(i)) {
-        candidates.push(values[i] - gap);
-        break; // Only need the nearest disabled handle
-      }
-    }
-    return Math.min(...candidates);
-  };
-
   // Values
   const offsetValues: OffsetValues = (values, offset, valueIndex, mode = 'unit') => {
     const nextValues = values.map<number>(formatValue);
     const originValue = nextValues[valueIndex];
 
-    const minBound = getHandleMinBound(nextValues, valueIndex);
-    const maxBound = getHandleMaxBound(nextValues, valueIndex);
+    const [minBound, maxBound] = getDisabledBoundaryValues(
+      nextValues,
+      valueIndex,
+      min,
+      max,
+      pushable,
+      isHandleDisabled,
+    );
 
     const nextValue = offsetValue(nextValues, offset, valueIndex, mode);
     nextValues[valueIndex] = nextValue;
 
-    // Apply disabled handle boundaries
-    // If bounds conflict (min > max), the handle is locked between two disabled handles
-    // In this case, keep the original value
     if (minBound <= maxBound) {
       nextValues[valueIndex] = Math.max(minBound, Math.min(maxBound, nextValues[valueIndex]));
     } else {
@@ -264,57 +306,85 @@ export default function useOffset(
       // =============== Push ==================
 
       // >>>>>> Basic push
-      // End values (skip disabled handles)
+      // End values
       for (let i = valueIndex + 1; i < nextValues.length; i += 1) {
         if (isHandleDisabled(i)) {
-          break; // Stop pushing when hitting a disabled handle
+          break;
         }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i], changed } = offsetChangedValue(nextValues, 1, i));
         }
-        // Apply boundary constraint to pushed handle
-        nextValues[i] = Math.min(nextValues[i], getHandleMaxBound(nextValues, i));
+        const [, itemMaxBound] = getDisabledBoundaryValues(
+          nextValues,
+          i,
+          min,
+          max,
+          pushable,
+          isHandleDisabled,
+        );
+        nextValues[i] = Math.min(nextValues[i], itemMaxBound);
       }
 
-      // Start values (skip disabled handles)
+      // Start values
       for (let i = valueIndex; i > 0; i -= 1) {
         if (isHandleDisabled(i - 1)) {
-          break; // Stop pushing when hitting a disabled handle
+          break;
         }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
-        // Apply boundary constraint to pushed handle
-        nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
+        const [itemMinBound] = getDisabledBoundaryValues(
+          nextValues,
+          i - 1,
+          min,
+          max,
+          pushable,
+          isHandleDisabled,
+        );
+        nextValues[i - 1] = Math.max(nextValues[i - 1], itemMinBound);
       }
 
       // >>>>> Revert back to safe push range
-      // End to Start (skip disabled handles)
+      // End to Start
       for (let i = nextValues.length - 1; i > 0; i -= 1) {
         if (isHandleDisabled(i) || isHandleDisabled(i - 1)) {
-          continue; // Skip if either handle is disabled
+          continue;
         }
         let changed = true;
         while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
-        // Apply boundary constraint to pushed handle
-        nextValues[i - 1] = Math.max(nextValues[i - 1], getHandleMinBound(nextValues, i - 1));
+        const [itemMinBound] = getDisabledBoundaryValues(
+          nextValues,
+          i - 1,
+          min,
+          max,
+          pushable,
+          isHandleDisabled,
+        );
+        nextValues[i - 1] = Math.max(nextValues[i - 1], itemMinBound);
       }
 
-      // Start to End (skip disabled handles)
+      // Start to End
       for (let i = 0; i < nextValues.length - 1; i += 1) {
         if (isHandleDisabled(i) || isHandleDisabled(i + 1)) {
-          continue; // Skip if either handle is disabled
+          continue;
         }
         let changed = true;
         while (needPush(nextValues[i + 1] - nextValues[i]) && changed) {
           ({ value: nextValues[i + 1], changed } = offsetChangedValue(nextValues, 1, i + 1));
         }
-        // Apply boundary constraint to pushed handle
-        nextValues[i + 1] = Math.min(nextValues[i + 1], getHandleMaxBound(nextValues, i + 1));
+        const [, itemMaxBound] = getDisabledBoundaryValues(
+          nextValues,
+          i + 1,
+          min,
+          max,
+          pushable,
+          isHandleDisabled,
+        );
+        nextValues[i + 1] = Math.min(nextValues[i + 1], itemMaxBound);
       }
     }
 

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -106,15 +106,12 @@ export const getClosestEnabledHandleIndex = (
   return closestIndex;
 };
 
-export default function useOffset(
+export function useFormatValue(
   min: number,
   max: number,
   step: number,
   markList: InternalMarkObj[],
-  allowCross: boolean,
-  pushable: false | number,
-  isHandleDisabled: IsHandleDisabled,
-): [FormatValue, OffsetValues] {
+): FormatValue {
   const formatRangeValue: FormatRangeValue = React.useCallback(
     (val) => Math.max(min, Math.min(max, val)),
     [min, max],
@@ -165,6 +162,37 @@ export default function useOffset(
       return closeValue;
     },
     [min, max, markList, step, formatRangeValue, formatStepValue],
+  );
+
+  return formatValue;
+}
+
+export default function useOffset(
+  min: number,
+  max: number,
+  step: number,
+  markList: InternalMarkObj[],
+  allowCross: boolean,
+  pushable: false | number,
+  formatValue: FormatValue,
+  isHandleDisabled: IsHandleDisabled,
+): OffsetValues {
+  const formatStepValue: FormatStepValue = React.useCallback(
+    (val) => {
+      if (step !== null) {
+        const rangedValue = Math.max(min, Math.min(max, val));
+        const stepValue = min + Math.round((rangedValue - min) / step) * step;
+
+        // Cut number in case to be like 0.30000000000000004
+        const getDecimal = (num: number) => (String(num).split('.')[1] || '').length;
+        const maxDecimal = Math.max(getDecimal(step), getDecimal(max), getDecimal(min));
+        const fixedValue = Number(stepValue.toFixed(maxDecimal));
+
+        return min <= fixedValue && fixedValue <= max ? fixedValue : null!;
+      }
+      return null!;
+    },
+    [step, min, max],
   );
 
   // ========================== Offset ==========================
@@ -404,5 +432,5 @@ export default function useOffset(
     };
   };
 
-  return [formatValue, offsetValues];
+  return offsetValues;
 }

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -30,6 +30,11 @@ export type OffsetValues = (
   values: number[];
 };
 
+/**
+ * Get the effective moving range for a handle.
+ * Disabled handles are treated as fixed anchors, and `pushable` is applied as the gap
+ * that enabled handles must keep away from those anchors.
+ */
 export const getDisabledBoundaryValues = (
   values: number[],
   valueIndex: number,
@@ -59,6 +64,11 @@ export const getDisabledBoundaryValues = (
   return [minBound, maxBound];
 };
 
+/**
+ * Find the nearest enabled handle that can accept the target value.
+ * A handle is only considered when the target value falls inside its disabled-anchor
+ * boundaries, so clicking outside an enabled segment becomes a no-op.
+ */
 export const getClosestEnabledHandleIndex = (
   values: number[],
   targetValue: number,

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -1064,5 +1064,33 @@ describe('Range', () => {
       expect(onChange).not.toHaveBeenCalled();
       expect(onDisabledChange).not.toHaveBeenCalled();
     });
+
+    it('click to move cannot cross disabled handle boundary', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range value={[20, 50, 80]} disabled={[true, false, false]} onChange={onChange} />,
+      );
+
+      // Click at position 10, which is left of disabled handle at 20
+      // Nearest enabled handle is 50, but it cannot cross below 20
+      doMouseDown(container, 10, 'rc-slider', true);
+
+      // Should move handle to 20 (boundary), not 10
+      expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
+    });
+
+    it('click to move cannot cross disabled handle on right side', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />,
+      );
+
+      // Click at position 90, which is right of disabled handle at 80
+      // Nearest enabled handle is 50, but it cannot cross above 80
+      doMouseDown(container, 90, 'rc-slider', true);
+
+      // Should move handle to 80 (boundary), not 90
+      expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
+    });
   });
 });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -1003,5 +1003,66 @@ describe('Range', () => {
       // Should not trigger onChange because all handles are disabled
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('editable: onDisabledChange called when adding handle', () => {
+      const onChange = jest.fn();
+      const onDisabledChange = jest.fn();
+      const { container } = render(
+        <Slider
+          range={{ editable: true }}
+          value={[0, 100]}
+          disabled={[true, false]}
+          onChange={onChange}
+          onDisabledChange={onDisabledChange}
+        />,
+      );
+
+      // Click to add a handle between 0 and 100
+      doMouseDown(container, 50, 'rc-slider', true);
+
+      expect(onChange).toHaveBeenCalledWith([0, 50, 100]);
+      expect(onDisabledChange).toHaveBeenCalledWith([true, false, false]);
+    });
+
+    it('editable: onDisabledChange called when removing handle', () => {
+      const onChange = jest.fn();
+      const onDisabledChange = jest.fn();
+      const { container } = render(
+        <Slider
+          range={{ editable: true }}
+          value={[0, 50, 100]}
+          disabled={[false, true, false]}
+          onChange={onChange}
+          onDisabledChange={onDisabledChange}
+        />,
+      );
+
+      // Drag first handle (enabled) out to delete it
+      doMouseMove(container, 0, 1000);
+
+      expect(onChange).toHaveBeenCalledWith([50, 100]);
+      expect(onDisabledChange).toHaveBeenCalledWith([true, false]);
+    });
+
+    it('editable: disabled array stays in sync when adding between disabled handles', () => {
+      const onChange = jest.fn();
+      const onDisabledChange = jest.fn();
+      const { container } = render(
+        <Slider
+          range={{ editable: true }}
+          value={[20, 60]}
+          disabled={[true, true]}
+          onChange={onChange}
+          onDisabledChange={onDisabledChange}
+        />,
+      );
+
+      // Click to add a handle between 20 and 60
+      doMouseDown(container, 40, 'rc-slider', true);
+
+      // Should not trigger onChange because both surrounding handles are disabled
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onDisabledChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -843,9 +843,9 @@ describe('Range', () => {
   });
 
   describe('disabled as array', () => {
-    it('basic', () => {
+    it('basic functionality with boolean and array', () => {
       const onChange = jest.fn();
-      const { container } = render(
+      const { container, rerender } = render(
         <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
       );
 
@@ -864,31 +864,30 @@ describe('Range', () => {
       // Keyboard: enabled handle should respond
       fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.RIGHT });
       expect(onChange).toHaveBeenCalledWith([0, 51, 100]);
+
+      // Boolean disabled backward compatibility
+      rerender(<Slider range defaultValue={[20, 50]} disabled={true} onChange={onChange} />);
+      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
+      doMouseDown(container, 30, 'rc-slider', true);
+      expect(onChange).toHaveBeenCalledTimes(1); // Still 1, not triggered
     });
 
-    it('drag disabled handle', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 50]} disabled={[true, false]} onChange={onChange} />,
-      );
-
-      // Try to drag disabled first handle
-      doMouseMove(container, 20, 80, 'rc-slider-handle');
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('click slider to move nearest enabled handle', () => {
+    it('drag and click respect disabled state', () => {
       const onChange = jest.fn();
       const { container } = render(
         <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
       );
 
-      // Click near disabled handle at 0, should move enabled handle at 50
+      // Drag disabled handle - no change
+      doMouseMove(container, 0, 80, 'rc-slider-handle');
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Click near disabled handle - moves nearest enabled handle
       doMouseDown(container, 10, 'rc-slider', true);
       expect(onChange).toHaveBeenCalledWith([0, 10, 100]);
     });
 
-    it('cannot cross disabled handle', () => {
+    it('cannot cross disabled handle boundary', () => {
       const onChange = jest.fn();
       const { container } = render(
         <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
@@ -902,129 +901,7 @@ describe('Range', () => {
       expect(lastCall[0][0]).toBeLessThanOrEqual(50);
     });
 
-    it('editable: cannot delete disabled handle', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range={{ editable: true }} defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
-      );
-
-      // Try to delete disabled middle handle
-      const handle = container.getElementsByClassName('rc-slider-handle')[1];
-      fireEvent.mouseEnter(handle);
-      fireEvent.keyDown(handle, { keyCode: keyCode.DELETE });
-      expect(onChange).not.toHaveBeenCalled();
-
-      // Try to drag out disabled handle
-      doMouseMove(container, 50, 1000, 'rc-slider-handle', 1);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('backward compatible with boolean', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 50]} disabled={true} onChange={onChange} />,
-      );
-
-      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
-      doMouseDown(container, 30, 'rc-slider', true);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('editable: cannot add handle between two disabled handles', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range={{ editable: true }} defaultValue={[20, 50, 80]} disabled={[true, true, false]} onChange={onChange} />,
-      );
-
-      // Click between 20 and 50, both are disabled
-      doMouseDown(container, 35, 'rc-slider', true);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('all handles disabled: click does nothing', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 50]} disabled={[true, true]} onChange={onChange} />,
-      );
-
-      const rail = container.querySelector('.rc-slider-rail');
-      const mouseDown = createEvent.mouseDown(rail);
-      Object.defineProperties(mouseDown, {
-        clientX: { get: () => 30 },
-        clientY: { get: () => 30 },
-      });
-      fireEvent(rail, mouseDown);
-
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('draggableTrack disabled when any handle is disabled', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range={{ draggableTrack: true }} defaultValue={[0, 50]} disabled={[false, true]} onChange={onChange} />,
-      );
-
-      // Try to drag track - should not work because one handle is disabled
-      const track = container.getElementsByClassName('rc-slider-track')[0];
-      const mouseDown = createEvent.mouseDown(track);
-      Object.defineProperties(mouseDown, {
-        clientX: { get: () => 0 },
-        clientY: { get: () => 0 },
-      });
-      fireEvent(track, mouseDown);
-
-      // Drag
-      const mouseMove = createEvent.mouseMove(document);
-      (mouseMove as any).pageX = 20;
-      (mouseMove as any).pageY = 20;
-      fireEvent(document, mouseMove);
-
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('all handles disabled: find nearest enabled returns -1', () => {
-      // This test specifically covers line 426 in Slider.tsx
-      // When all handles are disabled and clicking near one,
-      // the nearestIndex search returns -1 and returns early
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[0, 50, 100]} disabled={[true, true, true]} onChange={onChange} />,
-      );
-
-      // Click at position 10 (near first disabled handle)
-      const rail = container.querySelector('.rc-slider-rail');
-      const mouseDown = createEvent.mouseDown(rail);
-      Object.defineProperties(mouseDown, {
-        clientX: { get: () => 10 },
-        clientY: { get: () => 10 },
-      });
-      fireEvent(rail, mouseDown);
-
-      // Should not trigger onChange because all handles are disabled
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('editable: onDisabledChange called when adding handle', () => {
-      const onChange = jest.fn();
-      const onDisabledChange = jest.fn();
-      const { container } = render(
-        <Slider
-          range={{ editable: true }}
-          value={[0, 100]}
-          disabled={[true, false]}
-          onChange={onChange}
-          onDisabledChange={onDisabledChange}
-        />,
-      );
-
-      // Click to add a handle between 0 and 100
-      doMouseDown(container, 50, 'rc-slider', true);
-
-      expect(onChange).toHaveBeenCalledWith([0, 50, 100]);
-      expect(onDisabledChange).toHaveBeenCalledWith([true, false, false]);
-    });
-
-    it('editable: onDisabledChange called when removing handle', () => {
+    it('editable mode with disabled handles', () => {
       const onChange = jest.fn();
       const onDisabledChange = jest.fn();
       const { container } = render(
@@ -1037,17 +914,26 @@ describe('Range', () => {
         />,
       );
 
-      // Drag first handle (enabled) out to delete it
-      doMouseMove(container, 0, 1000);
+      // Cannot delete disabled handle
+      const handle = container.getElementsByClassName('rc-slider-handle')[1];
+      fireEvent.mouseEnter(handle);
+      fireEvent.keyDown(handle, { keyCode: keyCode.DELETE });
+      expect(onChange).not.toHaveBeenCalled();
 
+      // Cannot drag out disabled handle
+      doMouseMove(container, 50, 1000, 'rc-slider-handle', 1);
+      expect(onChange).not.toHaveBeenCalled();
+
+      // onDisabledChange called when removing enabled handle
+      doMouseMove(container, 0, 1000);
       expect(onChange).toHaveBeenCalledWith([50, 100]);
       expect(onDisabledChange).toHaveBeenCalledWith([true, false]);
     });
 
-    it('editable: disabled array stays in sync when adding between disabled handles', () => {
+    it('editable: add handle respects disabled boundaries', () => {
       const onChange = jest.fn();
       const onDisabledChange = jest.fn();
-      const { container } = render(
+      const { container, rerender } = render(
         <Slider
           range={{ editable: true }}
           value={[20, 60]}
@@ -1057,39 +943,77 @@ describe('Range', () => {
         />,
       );
 
-      // Click to add a handle between 20 and 60
+      // Cannot add between two disabled handles
       doMouseDown(container, 40, 'rc-slider', true);
-
-      // Should not trigger onChange because both surrounding handles are disabled
       expect(onChange).not.toHaveBeenCalled();
-      expect(onDisabledChange).not.toHaveBeenCalled();
+
+      // Can add when only one side is disabled
+      rerender(
+        <Slider
+          range={{ editable: true }}
+          value={[0, 100]}
+          disabled={[true, false]}
+          onChange={onChange}
+          onDisabledChange={onDisabledChange}
+        />,
+      );
+      doMouseDown(container, 50, 'rc-slider', true);
+      expect(onChange).toHaveBeenCalledWith([0, 50, 100]);
+      expect(onDisabledChange).toHaveBeenCalledWith([true, false, false]);
     });
 
-    it('click to move cannot cross disabled handle boundary', () => {
+    it('all handles disabled prevents interaction', () => {
       const onChange = jest.fn();
       const { container } = render(
+        <Slider range defaultValue={[0, 50, 100]} disabled={[true, true, true]} onChange={onChange} />,
+      );
+
+      // Click does nothing (covers findNearestEnabled returning -1)
+      const rail = container.querySelector('.rc-slider-rail');
+      const mouseDown = createEvent.mouseDown(rail);
+      Object.defineProperties(mouseDown, {
+        clientX: { get: () => 10 },
+        clientY: { get: () => 10 },
+      });
+      fireEvent(rail, mouseDown);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('draggableTrack disabled when any handle is disabled', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range={{ draggableTrack: true }} defaultValue={[0, 50]} disabled={[false, true]} onChange={onChange} />,
+      );
+
+      const track = container.getElementsByClassName('rc-slider-track')[0];
+      const mouseDown = createEvent.mouseDown(track);
+      Object.defineProperties(mouseDown, {
+        clientX: { get: () => 0 },
+        clientY: { get: () => 0 },
+      });
+      fireEvent(track, mouseDown);
+
+      const mouseMove = createEvent.mouseMove(document);
+      (mouseMove as any).pageX = 20;
+      (mouseMove as any).pageY = 20;
+      fireEvent(document, mouseMove);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('click to move respects disabled boundary', () => {
+      const onChange = jest.fn();
+      const { container, rerender } = render(
         <Slider range value={[20, 50, 80]} disabled={[true, false, false]} onChange={onChange} />,
       );
 
-      // Click at position 10, which is left of disabled handle at 20
-      // Nearest enabled handle is 50, but it cannot cross below 20
+      // Click left of disabled handle - clamped to boundary
       doMouseDown(container, 10, 'rc-slider', true);
-
-      // Should move handle to 20 (boundary), not 10
       expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
-    });
 
-    it('click to move cannot cross disabled handle on right side', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />,
-      );
-
-      // Click at position 90, which is right of disabled handle at 80
-      // Nearest enabled handle is 50, but it cannot cross above 80
+      // Click right of disabled handle - clamped to boundary
+      rerender(<Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />);
       doMouseDown(container, 90, 'rc-slider', true);
-
-      // Should move handle to 80 (boundary), not 90
       expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
     });
   });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -943,9 +943,9 @@ describe('Range', () => {
         />,
       );
 
-      // Cannot add between two disabled handles
       doMouseDown(container, 40, 'rc-slider', true);
       expect(onChange).not.toHaveBeenCalled();
+      expect(onDisabledChange).not.toHaveBeenCalled();
 
       // Can add when only one side is disabled
       rerender(
@@ -1015,6 +1015,71 @@ describe('Range', () => {
       rerender(<Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />);
       doMouseDown(container, 90, 'rc-slider', true);
       expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
+    });
+
+    it('pushable respects disabled handle boundaries', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable onChange={onChange} />,
+      );
+
+      // Push first handle right - should stop at disabled handle (40)
+      for (let i = 0; i < 30; i++) {
+        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.UP });
+      }
+
+      // First handle should not exceed 40 (position of disabled handle)
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(lastCall[0][0]).toBeLessThanOrEqual(40);
+      // Second handle is disabled at 40
+      expect(lastCall[0][1]).toBe(40);
+    });
+
+    it('pushable revert respects disabled handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[10, 20, 90, 100]} disabled={[false, true, false, false]} pushable={5} onChange={onChange} />,
+      );
+
+      // Move last handle left - should push third handle but stop at disabled
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[3], { keyCode: keyCode.LEFT });
+
+      // Third handle should not go below disabled handle at 20
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(lastCall[0][2]).toBeGreaterThanOrEqual(20);
+    });
+
+    it('keyboard home/end with disabled handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[true, false, true]} onChange={onChange} />,
+      );
+
+      // HOME key on enabled middle handle - should go to left disabled handle boundary (20)
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.HOME });
+      expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
+
+      onChange.mockClear();
+
+      // END key on enabled middle handle - should go to right disabled handle boundary (80)
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.END });
+      expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
+    });
+
+    it('allowCross false with disabled handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} allowCross={false} onChange={onChange} />,
+      );
+
+      // Try to move first handle past disabled middle handle
+      for (let i = 0; i < 50; i++) {
+        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
+      }
+
+      // First handle should not cross disabled handle at 50
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
     });
   });
 });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -30,8 +30,9 @@ describe('Range', () => {
     start: number,
     element = 'rc-slider-handle',
     skipEventCheck = false,
+    index = 0,
   ) {
-    const ele = container.getElementsByClassName(element)[0];
+    const ele = container.getElementsByClassName(element)[index];
     const mouseDown = createEvent.mouseDown(ele);
     (mouseDown as any).pageX = start;
     (mouseDown as any).pageY = start;
@@ -65,8 +66,9 @@ describe('Range', () => {
     start: number,
     end: number,
     element = 'rc-slider-handle',
+    index = 0,
   ) {
-    doMouseDown(container, start, element);
+    doMouseDown(container, start, element, false, index);
 
     // Drag
     doMouseDrag(end);
@@ -837,6 +839,169 @@ describe('Range', () => {
 
       doMouseDown(container, 50, 'rc-slider', true);
       expect(onChange).toHaveBeenCalledWith([0, 50]);
+    });
+  });
+
+  describe('disabled as array', () => {
+    it('basic', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
+      );
+
+      // Disabled handles: no tabIndex, aria-disabled=true
+      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
+      expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveAttribute('aria-disabled', 'true');
+
+      // Enabled handle: has tabIndex, aria-disabled=false
+      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveAttribute('tabIndex');
+      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveAttribute('aria-disabled', 'false');
+
+      // Keyboard: disabled handle should not respond
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Keyboard: enabled handle should respond
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.RIGHT });
+      expect(onChange).toHaveBeenCalledWith([0, 51, 100]);
+    });
+
+    it('drag disabled handle', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50]} disabled={[true, false]} onChange={onChange} />,
+      );
+
+      // Try to drag disabled first handle
+      doMouseMove(container, 20, 80, 'rc-slider-handle');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('click slider to move nearest enabled handle', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
+      );
+
+      // Click near disabled handle at 0, should move enabled handle at 50
+      doMouseDown(container, 10, 'rc-slider', true);
+      expect(onChange).toHaveBeenCalledWith([0, 10, 100]);
+    });
+
+    it('cannot cross disabled handle', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
+      );
+
+      // Try to move first handle past disabled middle handle
+      for (let i = 0; i < 50; i++) {
+        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
+      }
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
+    });
+
+    it('editable: cannot delete disabled handle', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range={{ editable: true }} defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
+      );
+
+      // Try to delete disabled middle handle
+      const handle = container.getElementsByClassName('rc-slider-handle')[1];
+      fireEvent.mouseEnter(handle);
+      fireEvent.keyDown(handle, { keyCode: keyCode.DELETE });
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Try to drag out disabled handle
+      doMouseMove(container, 50, 1000, 'rc-slider-handle', 1);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('backward compatible with boolean', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50]} disabled={true} onChange={onChange} />,
+      );
+
+      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
+      doMouseDown(container, 30, 'rc-slider', true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('editable: cannot add handle between two disabled handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range={{ editable: true }} defaultValue={[20, 50, 80]} disabled={[true, true, false]} onChange={onChange} />,
+      );
+
+      // Click between 20 and 50, both are disabled
+      doMouseDown(container, 35, 'rc-slider', true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('all handles disabled: click does nothing', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50]} disabled={[true, true]} onChange={onChange} />,
+      );
+
+      const rail = container.querySelector('.rc-slider-rail');
+      const mouseDown = createEvent.mouseDown(rail);
+      Object.defineProperties(mouseDown, {
+        clientX: { get: () => 30 },
+        clientY: { get: () => 30 },
+      });
+      fireEvent(rail, mouseDown);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('draggableTrack disabled when any handle is disabled', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range={{ draggableTrack: true }} defaultValue={[0, 50]} disabled={[false, true]} onChange={onChange} />,
+      );
+
+      // Try to drag track - should not work because one handle is disabled
+      const track = container.getElementsByClassName('rc-slider-track')[0];
+      const mouseDown = createEvent.mouseDown(track);
+      Object.defineProperties(mouseDown, {
+        clientX: { get: () => 0 },
+        clientY: { get: () => 0 },
+      });
+      fireEvent(track, mouseDown);
+
+      // Drag
+      const mouseMove = createEvent.mouseMove(document);
+      (mouseMove as any).pageX = 20;
+      (mouseMove as any).pageY = 20;
+      fireEvent(document, mouseMove);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('all handles disabled: find nearest enabled returns -1', () => {
+      // This test specifically covers line 426 in Slider.tsx
+      // When all handles are disabled and clicking near one,
+      // the nearestIndex search returns -1 and returns early
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[0, 50, 100]} disabled={[true, true, true]} onChange={onChange} />,
+      );
+
+      // Click at position 10 (near first disabled handle)
+      const rail = container.querySelector('.rc-slider-rail');
+      const mouseDown = createEvent.mouseDown(rail);
+      Object.defineProperties(mouseDown, {
+        clientX: { get: () => 10 },
+        clientY: { get: () => 10 },
+      });
+      fireEvent(rail, mouseDown);
+
+      // Should not trigger onChange because all handles are disabled
+      expect(onChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -901,65 +901,45 @@ describe('Range', () => {
       expect(lastCall[0][0]).toBeLessThanOrEqual(50);
     });
 
-    it('editable mode with disabled handles', () => {
+    it('editable mode disabled when any handle is disabled', () => {
       const onChange = jest.fn();
-      const onDisabledChange = jest.fn();
       const { container } = render(
         <Slider
           range={{ editable: true }}
           value={[0, 50, 100]}
           disabled={[false, true, false]}
           onChange={onChange}
-          onDisabledChange={onDisabledChange}
         />,
       );
 
-      // Cannot delete disabled handle
-      const handle = container.getElementsByClassName('rc-slider-handle')[1];
+      // Cannot delete handle when any handle is disabled (editable is disabled)
+      const handle = container.getElementsByClassName('rc-slider-handle')[0];
       fireEvent.mouseEnter(handle);
       fireEvent.keyDown(handle, { keyCode: keyCode.DELETE });
       expect(onChange).not.toHaveBeenCalled();
 
-      // Cannot drag out disabled handle
-      doMouseMove(container, 50, 1000, 'rc-slider-handle', 1);
-      expect(onChange).not.toHaveBeenCalled();
-
-      // onDisabledChange called when removing enabled handle
-      doMouseMove(container, 0, 1000);
-      expect(onChange).toHaveBeenCalledWith([50, 100]);
-      expect(onDisabledChange).toHaveBeenCalledWith([true, false]);
+      // Clicking track moves nearest enabled handle instead of adding new one
+      // (editable is disabled, so it falls back to normal behavior)
+      doMouseDown(container, 25, 'rc-slider', true);
+      // Should move first handle to position 25 instead of adding new handle
+      expect(onChange).toHaveBeenCalledWith([25, 50, 100]);
     });
 
-    it('editable: add handle respects disabled boundaries', () => {
+    it('editable mode completely disabled when any handle is disabled', () => {
       const onChange = jest.fn();
-      const onDisabledChange = jest.fn();
-      const { container, rerender } = render(
+      const { container } = render(
         <Slider
           range={{ editable: true }}
           value={[20, 60]}
-          disabled={[true, true]}
-          onChange={onChange}
-          onDisabledChange={onDisabledChange}
-        />,
-      );
-
-      doMouseDown(container, 40, 'rc-slider', true);
-      expect(onChange).not.toHaveBeenCalled();
-      expect(onDisabledChange).not.toHaveBeenCalled();
-
-      // Can add when only one side is disabled
-      rerender(
-        <Slider
-          range={{ editable: true }}
-          value={[0, 100]}
           disabled={[true, false]}
           onChange={onChange}
-          onDisabledChange={onDisabledChange}
         />,
       );
-      doMouseDown(container, 50, 'rc-slider', true);
-      expect(onChange).toHaveBeenCalledWith([0, 50, 100]);
-      expect(onDisabledChange).toHaveBeenCalledWith([true, false, false]);
+
+      // Clicking track moves nearest enabled handle (editable is disabled)
+      doMouseDown(container, 40, 'rc-slider', true);
+      // Should move second handle to position 40 instead of adding new handle
+      expect(onChange).toHaveBeenCalledWith([20, 40]);
     });
 
     it('all handles disabled prevents interaction', () => {

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -845,67 +845,77 @@ describe('Range', () => {
   });
 
   describe('disabled as array', () => {
-    it('basic functionality with boolean and array', () => {
+    const getHandle = (container: HTMLElement, index = 0) =>
+      container.getElementsByClassName('rc-slider-handle')[index] as HTMLElement;
+
+    const repeatKeyDown = (element: Element, code: number, count: number) => {
+      for (let i = 0; i < count; i += 1) {
+        fireEvent.keyDown(element, { keyCode: code });
+      }
+    };
+
+    const getLastChange = (onChange: jest.Mock) =>
+      onChange.mock.calls[onChange.mock.calls.length - 1][0];
+
+    it('respects handle disabled state and boolean disabled fallback', () => {
       const onChange = jest.fn();
       const { container, rerender } = render(
         <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
       );
 
-      // Disabled handles: no tabIndex, aria-disabled=true
-      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
-      expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveAttribute('aria-disabled', 'true');
+      const disabledHandle = getHandle(container, 0);
+      const enabledHandle = getHandle(container, 1);
 
-      // Enabled handle: has tabIndex, aria-disabled=false
-      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveAttribute('tabIndex');
-      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveAttribute('aria-disabled', 'false');
+      expect(disabledHandle).not.toHaveAttribute('tabIndex');
+      expect(disabledHandle).toHaveAttribute('aria-disabled', 'true');
+      expect(enabledHandle).toHaveAttribute('tabIndex');
+      expect(enabledHandle).toHaveAttribute('aria-disabled', 'false');
 
-      // Keyboard: disabled handle should not respond
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
+      fireEvent.keyDown(disabledHandle, { keyCode: keyCode.RIGHT });
+      doMouseMove(container, 0, 80, 'rc-slider-handle');
+      fireEvent.mouseUp(document);
       expect(onChange).not.toHaveBeenCalled();
 
-      // Keyboard: enabled handle should respond
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.RIGHT });
+      fireEvent.keyDown(enabledHandle, { keyCode: keyCode.RIGHT });
       expect(onChange).toHaveBeenCalledWith([0, 51, 100]);
 
-      // Boolean disabled backward compatibility
       rerender(<Slider range defaultValue={[20, 50]} disabled={true} onChange={onChange} />);
-      expect(container.getElementsByClassName('rc-slider-handle')[0]).not.toHaveAttribute('tabIndex');
+      expect(getHandle(container, 0)).not.toHaveAttribute('tabIndex');
       doMouseDown(container, 30, 'rc-slider', true);
-      expect(onChange).toHaveBeenCalledTimes(1); // Still 1, not triggered
+      fireEvent.mouseUp(document);
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
-    it('drag and click respect disabled state', () => {
+    it('moves only eligible handles when clicking the track', () => {
       const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
+      const { container, rerender } = render(
+        <Slider range value={[0, 50, 100]} disabled={[true, false, true]} onChange={onChange} />,
       );
 
-      // Drag disabled handle - no change
-      doMouseMove(container, 0, 80, 'rc-slider-handle');
+      doMouseDown(container, 10, 'rc-slider', true);
+      fireEvent.mouseUp(document);
+      expect(onChange).toHaveBeenCalledWith([0, 10, 100]);
+
+      onChange.mockClear();
+      rerender(<Slider range value={[20, 50, 80]} disabled={[true, false, false]} onChange={onChange} />);
+      doMouseDown(container, 10, 'rc-slider', true);
+      fireEvent.mouseUp(document);
       expect(onChange).not.toHaveBeenCalled();
 
-      // Click near disabled handle - moves nearest enabled handle
+      rerender(<Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />);
+      doMouseDown(container, 90, 'rc-slider', true);
+      fireEvent.mouseUp(document);
+      expect(onChange).not.toHaveBeenCalled();
+
+      rerender(<Slider range value={[0, 50, 100]} disabled={[true, true, true]} onChange={onChange} />);
       doMouseDown(container, 10, 'rc-slider', true);
-      expect(onChange).toHaveBeenCalledWith([0, 10, 100]);
+      fireEvent.mouseUp(document);
+      expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('cannot cross disabled handle boundary', () => {
+    it('disables editable operations when any handle is disabled', () => {
       const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
-      );
-
-      // Try to move first handle past disabled middle handle
-      for (let i = 0; i < 50; i++) {
-        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
-      }
-      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
-    });
-
-    it('editable mode disabled when any handle is disabled', () => {
-      const onChange = jest.fn();
-      const { container } = render(
+      const { container, rerender } = render(
         <Slider
           range={{ editable: true }}
           value={[0, 50, 100]}
@@ -914,22 +924,17 @@ describe('Range', () => {
         />,
       );
 
-      // Cannot delete handle when any handle is disabled (editable is disabled)
-      const handle = container.getElementsByClassName('rc-slider-handle')[0];
+      const handle = getHandle(container, 0);
       fireEvent.mouseEnter(handle);
       fireEvent.keyDown(handle, { keyCode: keyCode.DELETE });
       expect(onChange).not.toHaveBeenCalled();
 
-      // Clicking track moves nearest enabled handle instead of adding new one
-      // (editable is disabled, so it falls back to normal behavior)
       doMouseDown(container, 25, 'rc-slider', true);
-      // Should move first handle to position 25 instead of adding new handle
+      fireEvent.mouseUp(document);
       expect(onChange).toHaveBeenCalledWith([25, 50, 100]);
-    });
 
-    it('editable mode completely disabled when any handle is disabled', () => {
-      const onChange = jest.fn();
-      const { container } = render(
+      onChange.mockClear();
+      rerender(
         <Slider
           range={{ editable: true }}
           value={[20, 60]}
@@ -938,32 +943,14 @@ describe('Range', () => {
         />,
       );
 
-      // Clicking track moves nearest enabled handle (editable is disabled)
       doMouseDown(container, 40, 'rc-slider', true);
-      // Should move second handle to position 40 instead of adding new handle
+      fireEvent.mouseUp(document);
       expect(onChange).toHaveBeenCalledWith([20, 40]);
     });
 
-    it('all handles disabled prevents interaction', () => {
+    it('disables draggableTrack only when rendered handles are disabled', () => {
       const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[0, 50, 100]} disabled={[true, true, true]} onChange={onChange} />,
-      );
-
-      // Click does nothing (covers findNearestEnabled returning -1)
-      const rail = container.querySelector('.rc-slider-rail');
-      const mouseDown = createEvent.mouseDown(rail!);
-      Object.defineProperties(mouseDown, {
-        clientX: { get: () => 10 },
-        clientY: { get: () => 10 },
-      });
-      fireEvent(rail!, mouseDown);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('draggableTrack disabled when any handle is disabled', () => {
-      const onChange = jest.fn();
-      const { container } = render(
+      const { container, unmount } = render(
         <Slider range={{ draggableTrack: true }} defaultValue={[0, 50]} disabled={[false, true]} onChange={onChange} />,
       );
 
@@ -979,132 +966,89 @@ describe('Range', () => {
       (mouseMove as any).pageX = 20;
       (mouseMove as any).pageY = 20;
       fireEvent(document, mouseMove);
+      fireEvent.mouseUp(document);
 
       expect(onChange).not.toHaveBeenCalled();
-    });
 
-    it('ignores disabled config outside of rendered handles', () => {
-      const onChange = jest.fn();
-      const { container } = render(
+      unmount();
+
+      const onMove = jest.fn();
+      const { container: enabledContainer } = render(
         <Slider
           range={{ draggableTrack: true }}
           defaultValue={[20, 60]}
           disabled={[false, false, true]}
-          onChange={onChange}
+          onChange={onMove}
         />,
       );
 
-      doMouseMove(container, 20, 30, 'rc-slider-track');
-      expect(onChange).toHaveBeenCalledWith([30, 70]);
+      doMouseMove(enabledContainer, 20, 30, 'rc-slider-track');
+      fireEvent.mouseUp(document);
+      expect(onMove).toHaveBeenCalledWith([30, 70]);
     });
 
-    it('click to move respects disabled boundary', () => {
+    it('keeps keyboard movement inside disabled handle boundaries', () => {
       const onChange = jest.fn();
-      const { container, rerender } = render(
-        <Slider range value={[20, 50, 80]} disabled={[true, false, false]} onChange={onChange} />,
+      const { container, unmount } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} onChange={onChange} />,
       );
 
-      // Click left of disabled handle - no enabled segment contains the target
-      doMouseDown(container, 10, 'rc-slider', true);
-      expect(onChange).not.toHaveBeenCalled();
+      repeatKeyDown(getHandle(container, 0), keyCode.RIGHT, 50);
+      expect(getLastChange(onChange)[0]).toBeLessThanOrEqual(50);
 
-      // Click right of disabled handle - no enabled segment contains the target
-      rerender(<Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />);
-      doMouseDown(container, 90, 'rc-slider', true);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('pushable respects disabled handle boundaries', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable={10} onChange={onChange} />,
-      );
-
-      // Push first handle right - should stop at disabled handle boundary (40 - 10 = 30)
-      for (let i = 0; i < 30; i++) {
-        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.UP });
-      }
-
-      // First handle should stop at 30 to maintain pushable distance from disabled handle at 40
-      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][0]).toBe(30);
-      expect(lastCall[0][1]).toBe(40);
-    });
-
-    it('pushable revert respects disabled handles', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable={10} onChange={onChange} />,
-      );
-
-      // Drag last handle (80) left to push third handle (60) toward disabled handle (40)
-      for (let i = 0; i < 50; i++) {
-        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[3], { keyCode: keyCode.LEFT });
-      }
-
-      // Third handle should maintain pushable distance from disabled handle at 40
-      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][2]).toBe(50);
-      expect(lastCall[0][2] - lastCall[0][1]).toBe(10);
-    });
-
-    it('keyboard home/end with disabled handles', () => {
-      const onChange = jest.fn();
-      const { container } = render(
-        <Slider range defaultValue={[20, 50, 80]} disabled={[true, false, true]} onChange={onChange} />,
-      );
-
-      // HOME key on enabled middle handle - should go to left disabled handle boundary (20)
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.HOME });
-      expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
-
+      unmount();
       onChange.mockClear();
 
-      // END key on enabled middle handle - should go to right disabled handle boundary (80)
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.END });
-      expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
-    });
-
-    it('keeps focus on enabled handle when keyboard moves to disabled boundary', () => {
-      const { container } = render(
-        <Slider range defaultValue={[20, 50, 80]} disabled={[true, false, true]} />,
+      const { container: boundaryContainer } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[true, false, true]} onChange={onChange} />,
       );
-      const middleHandle = container.getElementsByClassName('rc-slider-handle')[1] as HTMLElement;
+      const middleHandle = getHandle(boundaryContainer, 1);
 
       middleHandle.focus();
       fireEvent.keyDown(middleHandle, { keyCode: keyCode.HOME });
+      expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
+      expect(getHandle(boundaryContainer, 1)).toHaveFocus();
 
-      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveFocus();
+      onChange.mockClear();
+      fireEvent.keyDown(getHandle(boundaryContainer, 1), { keyCode: keyCode.END });
+      expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
     });
 
-    it('allowCross false with disabled handles', () => {
+    it('respects pushable boundaries around disabled handles', () => {
       const onChange = jest.fn();
       const { container } = render(
+        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable={10} onChange={onChange} />,
+      );
+
+      repeatKeyDown(getHandle(container, 0), keyCode.UP, 30);
+      expect(getLastChange(onChange)[0]).toBe(30);
+      expect(getLastChange(onChange)[1]).toBe(40);
+
+      onChange.mockClear();
+
+      repeatKeyDown(getHandle(container, 3), keyCode.LEFT, 50);
+      expect(getLastChange(onChange)[2]).toBe(50);
+      expect(getLastChange(onChange)[2] - getLastChange(onChange)[1]).toBe(10);
+    });
+
+    it('respects disabled boundaries with allowCross=false and step=null', () => {
+      const onChange = jest.fn();
+      const { container, unmount } = render(
         <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} allowCross={false} onChange={onChange} />,
       );
 
-      // Try to move first handle past disabled middle handle
-      for (let i = 0; i < 50; i++) {
-        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
-      }
+      repeatKeyDown(getHandle(container, 0), keyCode.RIGHT, 50);
+      expect(getLastChange(onChange)[0]).toBeLessThanOrEqual(50);
 
-      // First handle should not cross disabled handle at 50
-      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
-    });
+      unmount();
+      onChange.mockClear();
 
-    it('pushable with step=null and disabled handles', () => {
-      const onChange = jest.fn();
-      const { container } = render(
+      const { container: stepContainer } = render(
         <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} step={null} marks={{ 0: '0', 50: '50', 100: '100' }} pushable={10} onChange={onChange} />,
       );
 
-      // Push first handle right - should stop at disabled handle
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
-
-      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      // First handle should not exceed disabled handle boundary (50) minus pushable
-      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
+      fireEvent.keyDown(getHandle(stepContainer, 0), { keyCode: keyCode.RIGHT });
+      expect(getLastChange(onChange)[0]).toBeLessThanOrEqual(50);
     });
   });
 });

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -983,20 +983,35 @@ describe('Range', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('ignores disabled config outside of rendered handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider
+          range={{ draggableTrack: true }}
+          defaultValue={[20, 60]}
+          disabled={[false, false, true]}
+          onChange={onChange}
+        />,
+      );
+
+      doMouseMove(container, 20, 30, 'rc-slider-track');
+      expect(onChange).toHaveBeenCalledWith([30, 70]);
+    });
+
     it('click to move respects disabled boundary', () => {
       const onChange = jest.fn();
       const { container, rerender } = render(
         <Slider range value={[20, 50, 80]} disabled={[true, false, false]} onChange={onChange} />,
       );
 
-      // Click left of disabled handle - clamped to boundary
+      // Click left of disabled handle - no enabled segment contains the target
       doMouseDown(container, 10, 'rc-slider', true);
-      expect(onChange).toHaveBeenCalledWith([20, 20, 80]);
+      expect(onChange).not.toHaveBeenCalled();
 
-      // Click right of disabled handle - clamped to boundary
+      // Click right of disabled handle - no enabled segment contains the target
       rerender(<Slider range value={[20, 50, 80]} disabled={[false, false, true]} onChange={onChange} />);
       doMouseDown(container, 90, 'rc-slider', true);
-      expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('pushable respects disabled handle boundaries', () => {
@@ -1048,6 +1063,18 @@ describe('Range', () => {
       // END key on enabled middle handle - should go to right disabled handle boundary (80)
       fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[1], { keyCode: keyCode.END });
       expect(onChange).toHaveBeenCalledWith([20, 80, 80]);
+    });
+
+    it('keeps focus on enabled handle when keyboard moves to disabled boundary', () => {
+      const { container } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[true, false, true]} />,
+      );
+      const middleHandle = container.getElementsByClassName('rc-slider-handle')[1] as HTMLElement;
+
+      middleHandle.focus();
+      fireEvent.keyDown(middleHandle, { keyCode: keyCode.HOME });
+
+      expect(container.getElementsByClassName('rc-slider-handle')[1]).toHaveFocus();
     });
 
     it('allowCross false with disabled handles', () => {

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -1020,33 +1020,35 @@ describe('Range', () => {
     it('pushable respects disabled handle boundaries', () => {
       const onChange = jest.fn();
       const { container } = render(
-        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable onChange={onChange} />,
+        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable={10} onChange={onChange} />,
       );
 
-      // Push first handle right - should stop at disabled handle (40)
+      // Push first handle right - should stop at disabled handle boundary (40 - 10 = 30)
       for (let i = 0; i < 30; i++) {
         fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.UP });
       }
 
-      // First handle should not exceed 40 (position of disabled handle)
+      // First handle should stop at 30 to maintain pushable distance from disabled handle at 40
       const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][0]).toBeLessThanOrEqual(40);
-      // Second handle is disabled at 40
+      expect(lastCall[0][0]).toBe(30);
       expect(lastCall[0][1]).toBe(40);
     });
 
     it('pushable revert respects disabled handles', () => {
       const onChange = jest.fn();
       const { container } = render(
-        <Slider range defaultValue={[10, 20, 90, 100]} disabled={[false, true, false, false]} pushable={5} onChange={onChange} />,
+        <Slider range defaultValue={[20, 40, 60, 80]} disabled={[false, true, false, false]} pushable={10} onChange={onChange} />,
       );
 
-      // Move last handle left - should push third handle but stop at disabled
-      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[3], { keyCode: keyCode.LEFT });
+      // Drag last handle (80) left to push third handle (60) toward disabled handle (40)
+      for (let i = 0; i < 50; i++) {
+        fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[3], { keyCode: keyCode.LEFT });
+      }
 
-      // Third handle should not go below disabled handle at 20
+      // Third handle should maintain pushable distance from disabled handle at 40
       const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(lastCall[0][2]).toBeGreaterThanOrEqual(20);
+      expect(lastCall[0][2]).toBe(50);
+      expect(lastCall[0][2] - lastCall[0][1]).toBe(10);
     });
 
     it('keyboard home/end with disabled handles', () => {
@@ -1079,6 +1081,20 @@ describe('Range', () => {
 
       // First handle should not cross disabled handle at 50
       const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(lastCall[0][0]).toBeLessThanOrEqual(50);
+    });
+
+    it('pushable with step=null and disabled handles', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Slider range defaultValue={[20, 50, 80]} disabled={[false, true, false]} step={null} marks={{ 0: '0', 50: '50', 100: '100' }} pushable={10} onChange={onChange} />,
+      );
+
+      // Push first handle right - should stop at disabled handle
+      fireEvent.keyDown(container.getElementsByClassName('rc-slider-handle')[0], { keyCode: keyCode.RIGHT });
+
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+      // First handle should not exceed disabled handle boundary (50) minus pushable
       expect(lastCall[0][0]).toBeLessThanOrEqual(50);
     });
   });

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -511,6 +511,18 @@ describe('Slider', () => {
     expect(container.getElementsByClassName('rc-slider-track')).toHaveLength(1);
   });
 
+  it('should not change null value when disabled', () => {
+    const onChange = jest.fn();
+    const { container } = render(<Slider value={null} disabled onChange={onChange} />);
+
+    fireEvent.mouseDown(container.querySelector('.rc-slider'), {
+      clientX: 20,
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(container.getElementsByClassName('rc-slider-track')).toHaveLength(0);
+  });
+
   describe('click slider to change value', () => {
     it('ltr', () => {
       const onChange = jest.fn();


### PR DESCRIPTION
## 功能说明

本 PR 新增了 **per-handle disabled** 功能，允许在 Range 滑块中单独禁用特定的 handle：

- `disabled` 支持数组类型，如 `[true, false, true]` 可禁用第1和第3个 handle
- 禁用 handle 会作为移动边界，其他 handle 无法越过
- pushable 配置会考虑禁用的 handle 作为边界
- 当任意 handle 被禁用时，editable 模式自动禁用
- 添加了禁用 handle 的视觉样式（灰色边框、not-allowed 光标）

## 使用示例

```tsx
<Slider 
  range 
  value={[10, 50, 90]} 
  disabled={[false, true, false]}  // 禁用中间 handle
/>
// 中间 handle (50) 作为边界，第一个 handle 无法超越 50，第三个 handle 无法低于 50
```

## 关联 issue
https://github.com/ant-design/ant-design/issues/10143

## 测试覆盖
- ✅ 所有现有测试通过
- ✅ 添加禁用 handle 行为测试
- ✅ 添加作为边界的测试
- ✅ 添加 pushable 配合测试