### PR TITLE
fix: guard drag movement without container

### DIFF
--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -168,13 +168,18 @@ function useDrag(
 
     // Moving
     const onMouseMove: EventListener = (event) => {
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+
       event.preventDefault();
 
       const { pageX: moveX, pageY: moveY } = getPosition(event as MouseEvent | TouchEvent);
       const offsetX = moveX - startX;
       const offsetY = moveY - startY;
 
-      const { width, height } = containerRef.current!.getBoundingClientRect();
+      const { width, height } = container.getBoundingClientRect();
 
       let offSetPercent: number;
       let removeDist: number;

--- a/tests/useDrag.test.tsx
+++ b/tests/useDrag.test.tsx
@@ -1,0 +1,65 @@
+import { act, createEvent, fireEvent, renderHook } from '@testing-library/react';
+import type React from 'react';
+import useDrag from '../src/hooks/useDrag';
+
+describe('useDrag', () => {
+  it('should ignore mouse movement when the container is no longer available', () => {
+    const containerRef: React.RefObject<HTMLDivElement | null> = {
+      current: document.createElement('div'),
+    };
+    const rawValues = [50];
+    const triggerChange = jest.fn();
+    const finishChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useDrag(
+        containerRef,
+        'ltr',
+        rawValues,
+        0,
+        100,
+        (value) => value,
+        triggerChange,
+        finishChange,
+        (values, offset, valueIndex) => {
+          const value = values[valueIndex] + Number(offset);
+          return { value, values: [value] };
+        },
+        false,
+        0,
+        () => false,
+      ),
+    );
+
+    const eventTarget = document.createElement('div');
+    act(() => {
+      result.current[4](
+        {
+          currentTarget: eventTarget,
+          pageX: 0,
+          pageY: 0,
+          stopPropagation: jest.fn(),
+        } as unknown as React.MouseEvent,
+        0,
+      );
+    });
+
+    containerRef.current = null;
+    const mouseMove = createEvent.mouseMove(document);
+    Object.defineProperties(mouseMove, {
+      pageX: { value: 20 },
+      pageY: { value: 0 },
+    });
+
+    expect(() => fireEvent(document, mouseMove)).not.toThrow();
+    expect(triggerChange).not.toHaveBeenCalled();
+
+    fireEvent.mouseUp(document);
+    expect(finishChange).toHaveBeenCalledWith(false);
+    expect(finishChange).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toBe(-1);
+
+    fireEvent.mouseUp(document);
+    expect(finishChange).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- ignore active drag move events after the slider container ref becomes unavailable
- keep the existing mouseup/touchend cleanup and finish path intact
- add a hook-level regression test that covers the reported null-ref crash and verifies drag cleanup

Fixes #1063.

## Why

The document-level move listener can run after `containerRef.current` becomes null. It currently dereferences the ref unconditionally and throws while reading `getBoundingClientRect()`. The listener now snapshots the container and returns only for that move when it is unavailable. The independent end handler still removes all listeners, calls `finishChange`, and resets drag state.

## Validation

- Exact-base red proof: the new regression fails on `9982e48` with `TypeError: Cannot read properties of null (reading getBoundingClientRect)`
- `npm test -- tests/useDrag.test.tsx --runInBand` — 1/1 passed
- `npm test -- --runInBand` — 6 suites, 122/122 tests, 5/5 snapshots passed
- `npm run tsc`
- `npm run lint`
- `npx eslint src/hooks/useDrag.ts tests/useDrag.test.tsx`
- `npx prettier --check src/hooks/useDrag.ts tests/useDrag.test.tsx`
- `npm run compile`
- `git diff --check`

The full suite still prints pre-existing React `act(...)` warnings in unchanged Range/Slider focus tests; it exits successfully and the new regression is warning-free.

I checked all 34 open PRs and their complete changed-file lists before submission; none touches either target file. The older merged #210 documents the same ref-null failure class in the pre-hook implementation and establishes a regression-test precedent, while no current duplicate patch exists.

AI assistance disclosure: Codex was used to reproduce the exact-base failure, trace the move/end listener ownership, draft the focused guard and regression, audit open PR overlap, and run the validation above. All behavior, test counts, commit state, and duplicate checks are directly verifiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复拖拽过程中容器暂时不可用时可能发生的异常。
  - 在此情况下，拖拽位置不会被错误更新，释放鼠标后仍可正常完成拖拽。
- **测试**
  - 新增相关测试，验证异常场景下的拖拽行为和完成回调处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->