### PR TITLE
fix: support keyboard activation for marks

### DIFF
--- a/src/Marks/Mark.tsx
+++ b/src/Marks/Mark.tsx
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx';
+import { KeyCode } from '@rc-component/util';
 import * as React from 'react';
 import SliderContext from '../context';
 import { getDirectionStyle } from '../util';
@@ -13,7 +14,7 @@ export interface MarkProps {
 
 const Mark: React.FC<MarkProps> = (props) => {
   const { prefixCls, style, children, value, onClick } = props;
-  const { min, max, direction, includedStart, includedEnd, included } =
+  const { min, max, direction, disabled, includedStart, includedEnd, included } =
     React.useContext(SliderContext);
 
   const textCls = `${prefixCls}-text`;
@@ -23,6 +24,9 @@ const Mark: React.FC<MarkProps> = (props) => {
 
   return (
     <span
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
       className={clsx(textCls, {
         [`${textCls}-active`]: included && includedStart <= value && value <= includedEnd,
       })}
@@ -31,7 +35,15 @@ const Mark: React.FC<MarkProps> = (props) => {
         e.stopPropagation();
       }}
       onClick={() => {
-        onClick(value);
+        if (!disabled) {
+          onClick(value);
+        }
+      }}
+      onKeyDown={(event) => {
+        if (!disabled && (event.which === KeyCode.ENTER || event.which === KeyCode.SPACE)) {
+          event.preventDefault();
+          onClick(value);
+        }
       }}
     >
       {children}

--- a/tests/marks.test.js
+++ b/tests/marks.test.js
@@ -37,7 +37,9 @@ describe('marks', () => {
     const marks = { 0: '0', 30: '30', 100: '100' };
     const onChange = jest.fn();
     const onChangeComplete = jest.fn();
-    const { container } = render(<Slider marks={marks} onChange={onChange} onChangeComplete={onChangeComplete} />);
+    const { container } = render(
+      <Slider marks={marks} onChange={onChange} onChangeComplete={onChangeComplete} />,
+    );
     fireEvent.click(container.getElementsByClassName('rc-slider-mark-text')[1]);
     expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveAttribute(
       'aria-valuenow',
@@ -47,6 +49,48 @@ describe('marks', () => {
     expect(onChange).toHaveBeenCalledWith(30);
     expect(onChangeComplete).toHaveBeenCalledTimes(1);
     expect(onChangeComplete).toHaveBeenCalledWith(30);
+  });
+
+  it('should select marks with Enter and Space', () => {
+    const onChange = jest.fn();
+    const onChangeComplete = jest.fn();
+    const { container, getByRole } = render(
+      <Slider
+        marks={{ 0: 'Start', 30: 'Middle', 100: 'End' }}
+        onChange={onChange}
+        onChangeComplete={onChangeComplete}
+      />,
+    );
+
+    const middleMark = getByRole('button', { name: 'Middle' });
+    const endMark = getByRole('button', { name: 'End' });
+
+    expect(fireEvent.keyDown(middleMark, { key: 'Enter', keyCode: 13, which: 13 })).toBe(false);
+    expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveAttribute(
+      'aria-valuenow',
+      '30',
+    );
+    expect(fireEvent.keyDown(endMark, { key: ' ', keyCode: 32, which: 32 })).toBe(false);
+    expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+    expect(onChange).toHaveBeenNthCalledWith(1, 30);
+    expect(onChange).toHaveBeenNthCalledWith(2, 100);
+    expect(onChangeComplete).toHaveBeenNthCalledWith(1, 30);
+    expect(onChangeComplete).toHaveBeenNthCalledWith(2, 100);
+  });
+
+  it('should expose disabled marks without adding them to the tab order', () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(<Slider disabled marks={{ 30: 'Middle' }} onChange={onChange} />);
+
+    const mark = getByRole('button', { name: 'Middle' });
+
+    expect(mark).toHaveAttribute('aria-disabled', 'true');
+    expect(mark).toHaveAttribute('tabindex', '-1');
+    fireEvent.keyDown(mark, { key: 'Enter', keyCode: 13, which: 13 });
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   // TODO: not implement yet


### PR DESCRIPTION
## Summary

- expose clickable mark labels with button semantics
- support Enter and Space activation while preventing Space scrolling
- remove disabled marks from sequential focus and guard mouse and keyboard activation

## Verification

- reproduced on the exact master base with two regression tests that failed because marks had no button semantics
- 5 test suites, 123 tests, and 5 snapshots pass
- TypeScript, focused ESLint, Prettier, full ESM/CJS/declaration/CSS build, and diff checks pass

## Overlap audit

- #949 changes mark styling APIs only
- #866 is an older performance proposal that removes the current mark click path and does not add keyboard semantics
- #842 adds a dot class and does not change mark interaction

AI assistance disclosure: Codex was used to trace the interaction path, audit open PR overlap, write the implementation and regression tests, and run validation. The behavior and results above were verified directly on this exact commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持通过键盘 Enter 或空格键选择滑块标记。
  * 标记项现具备更完善的键盘可访问性，并正确反映禁用状态。

* **错误修复**
  * 禁用的标记项不再响应点击或键盘操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->