### PR TITLE
fix: preserve decimal pushable gaps

### DIFF
--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -266,8 +266,21 @@ export default function useOffset(
     };
   };
 
-  const needPush = (dist: number) => {
-    return (pushable === null && dist === 0) || (typeof pushable === 'number' && dist < pushable);
+  const needPush = (startValue: number, endValue: number) => {
+    const dist = endValue - startValue;
+
+    if (pushable === null) {
+      return dist === 0;
+    }
+
+    if (typeof pushable === 'number') {
+      // Aligned decimal values can subtract to just below the configured gap.
+      const tolerance =
+        Number.EPSILON * Math.max(Math.abs(startValue), Math.abs(endValue), Math.abs(pushable));
+      return dist < pushable - tolerance;
+    }
+
+    return false;
   };
 
   // Values
@@ -322,7 +335,7 @@ export default function useOffset(
           break;
         }
         let changed = true;
-        while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
+        while (needPush(nextValues[i - 1], nextValues[i]) && changed) {
           ({ value: nextValues[i], changed } = offsetChangedValue(nextValues, 1, i));
         }
         const [, itemMaxBound] = getDisabledBoundaryValues(
@@ -342,7 +355,7 @@ export default function useOffset(
           break;
         }
         let changed = true;
-        while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
+        while (needPush(nextValues[i - 1], nextValues[i]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
         const [itemMinBound] = getDisabledBoundaryValues(
@@ -363,7 +376,7 @@ export default function useOffset(
           continue;
         }
         let changed = true;
-        while (needPush(nextValues[i] - nextValues[i - 1]) && changed) {
+        while (needPush(nextValues[i - 1], nextValues[i]) && changed) {
           ({ value: nextValues[i - 1], changed } = offsetChangedValue(nextValues, -1, i - 1));
         }
         const [itemMinBound] = getDisabledBoundaryValues(
@@ -383,7 +396,7 @@ export default function useOffset(
           continue;
         }
         let changed = true;
-        while (needPush(nextValues[i + 1] - nextValues[i]) && changed) {
+        while (needPush(nextValues[i], nextValues[i + 1]) && changed) {
           ({ value: nextValues[i + 1], changed } = offsetChangedValue(nextValues, 1, i + 1));
         }
         const [, itemMaxBound] = getDisabledBoundaryValues(

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -268,19 +268,16 @@ export default function useOffset(
 
   const needPush = (startValue: number, endValue: number) => {
     const dist = endValue - startValue;
+    // Aligned decimal values can subtract to just below the configured gap.
+    const tolerance =
+      typeof pushable === 'number'
+        ? Number.EPSILON * Math.max(Math.abs(startValue), Math.abs(endValue), Math.abs(pushable))
+        : 0;
 
-    if (pushable === null) {
-      return dist === 0;
-    }
-
-    if (typeof pushable === 'number') {
-      // Aligned decimal values can subtract to just below the configured gap.
-      const tolerance =
-        Number.EPSILON * Math.max(Math.abs(startValue), Math.abs(endValue), Math.abs(pushable));
-      return dist < pushable - tolerance;
-    }
-
-    return false;
+    return (
+      (pushable === null && dist === 0) ||
+      (typeof pushable === 'number' && dist < pushable - tolerance)
+    );
   };
 
   // Values

--- a/src/hooks/useOffset.ts
+++ b/src/hooks/useOffset.ts
@@ -270,9 +270,8 @@ export default function useOffset(
     const dist = endValue - startValue;
     // Aligned decimal values can subtract to just below the configured gap.
     const tolerance =
-      typeof pushable === 'number'
-        ? Number.EPSILON * Math.max(Math.abs(startValue), Math.abs(endValue), Math.abs(pushable))
-        : 0;
+      Number.EPSILON *
+      Math.max(Math.abs(startValue), Math.abs(endValue), Math.abs(Number(pushable)));
 
     return (
       (pushable === null && dist === 0) ||

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -328,6 +328,28 @@ describe('Range', () => {
     expect(onChange).toHaveBeenCalledWith([0, 90, 100]);
   });
 
+  it('pushes decimal handles in both directions', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Slider
+        range
+        min={0}
+        max={1}
+        step={0.1}
+        pushable={0.1}
+        defaultValue={[0.5, 0.6, 0.7]}
+        onChange={onChange}
+      />,
+    );
+    doMouseMove(container, 50, 60, 'rc-slider-handle', 0);
+    fireEvent.mouseUp(document);
+    expect(onChange).toHaveBeenLastCalledWith([0.6, 0.7, 0.8]);
+
+    doMouseMove(container, 80, 70, 'rc-slider-handle', 2);
+    fireEvent.mouseUp(document);
+    expect(onChange).toHaveBeenLastCalledWith([0.5, 0.6, 0.7]);
+  });
+
   describe('should render correctly when allowCross', () => {
     function testLTR(name, func) {
       it(name, () => {


### PR DESCRIPTION
## Summary

- compare pushable gaps with a magnitude-scaled floating-point tolerance
- avoid pushing decimal handles more than one aligned step when their gap is already equal to `pushable`
- add a mouse-drag regression that pushes a three-handle range in both directions

Fixes #227.

## Problem

Aligned decimal values can still produce an inexact result when subtracted. For example, `0.7 - 0.6` is slightly less than `0.1`, so the current raw `dist < pushable` check treats an already valid gap as too small and pushes the surrounding handle again. Dragging `[0.5, 0.6, 0.7]` one step to the right therefore jumps to `[0.6, 0.8, 1]` instead of `[0.6, 0.7, 0.8]`.

The tolerance is scaled from the compared handle values and configured gap, so it only absorbs representational noise at their magnitude; genuinely smaller gaps continue through the existing push loop.

## Verification

- Exact base: `02260ea7a23e09a76f34d9c59d41c9aae8561140`
- Regression proof: on the exact base, the new mouse-drag test fails with `[0.6, 0.8, 1]` instead of `[0.6, 0.7, 0.8]`
- `npm test -- --runInBand` — 5/5 suites, 122/122 tests, 5/5 snapshots passed
- `npm run tsc` — passed
- `npm run lint` — passed
- `npm run compile` — passed
- `git diff --check` — passed

The full test run retains the repositorys existing React `act(...)` console warnings; it has no test failures.

## Overlap audit

Open PR #904 touches `useOffset.ts` in the separate `allowCross={false}` branch and does not change the pushable distance comparison. Open PRs #1055 and #1089 touch `Range.test.tsx` for unrelated deprecated-API and drag-completion coverage. No open PR implements the decimal-gap correction.

## AI assistance disclosure

Codex was used to reproduce the old report on current master, trace the current push loop, implement the tolerance, audit overlapping open PR files, and run the verification above. I reviewed the diff and results before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复小数步长场景下，拖动范围滑块时相邻句柄无法准确推动的问题。
  * 提升十进制数值对齐的计算准确性，避免浮点误差导致错误判断。

* **测试**
  * 新增双向拖动小数句柄的验证，确保句柄按预期步长更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->