### PR TITLE
fix: preserve pushable gaps on track clicks

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -395,13 +395,32 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
       });
 
       let focusIndex: number;
+      let valueOffset = 0;
 
-      if (effectiveRangeEditable && valueDist !== 0 && (!maxCount || rawValues.length < maxCount)) {
+      if (!rawValues.length) {
+        cloneNextValues.push(newValue);
+        focusIndex = 0;
+      } else if (
+        effectiveRangeEditable &&
+        valueDist !== 0 &&
+        (!maxCount || rawValues.length < maxCount)
+      ) {
         cloneNextValues.splice(valueBeforeIndex + 1, 0, newValue);
         focusIndex = valueBeforeIndex + 1;
       } else {
-        cloneNextValues[valueIndex] = newValue;
+        valueOffset = newValue - rawValues[valueIndex];
         focusIndex = valueIndex;
+      }
+
+      if (rawValues.length) {
+        // Keep track clicks consistent with drag and keyboard constraints.
+        const { values: nextValues } = offsetValues(
+          cloneNextValues,
+          valueOffset,
+          focusIndex,
+          'dist',
+        );
+        cloneNextValues.splice(0, cloneNextValues.length, ...nextValues);
       }
 
       // Fill value to match default 2 (only when `rawValues` is empty)

--- a/tests/Range.test.tsx
+++ b/tests/Range.test.tsx
@@ -856,6 +856,35 @@ describe('Range', () => {
     });
   });
 
+  it('keeps pushable when clicking the track', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Slider range defaultValue={[20, 40]} pushable={20} onChange={onChange} />,
+    );
+
+    doMouseDown(container, 30, 'rc-slider', true);
+    fireEvent.mouseUp(document);
+
+    expect(onChange).toHaveBeenLastCalledWith([10, 30]);
+  });
+
+  it('keeps pushable when inserting an editable handle', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Slider
+        range={{ editable: true }}
+        defaultValue={[20, 40]}
+        pushable={20}
+        onChange={onChange}
+      />,
+    );
+
+    doMouseDown(container, 30, 'rc-slider', true);
+    fireEvent.mouseUp(document);
+
+    expect(onChange).toHaveBeenLastCalledWith([10, 30, 50]);
+  });
+
   describe('disabled as array', () => {
     const getHandle = (container: HTMLElement, index = 0) =>
       container.getElementsByClassName('rc-slider-handle')[index] as HTMLElement;


### PR DESCRIPTION
## Summary

- route track-click value changes through the same `offsetValues` constraints used by drag and keyboard movement
- preserve `pushable` gaps for both existing ranges and editable handle insertion
- retain the existing empty-range initialization path

Fixes #200.

## Problem

Track clicks currently replace or insert the nearest value directly, bypassing the pushable algorithm. With `[20, 40]` and `pushable={20}`, clicking 30 emits `[20, 30]`; editable mode emits `[20, 30, 40]`. Both results violate the documented minimum adjacent gap.

The corrected path keeps the clicked value at 30 and pushes its neighbors through the existing distance-mode algorithm, producing `[10, 30]` and `[10, 30, 50]` respectively. Non-range, disabled, allow-cross, and null-range paths continue through their existing branches; the full suite covers those boundaries.

## Verification

- Exact base: `02260ea7a23e09a76f34d9c59d41c9aae8561140`
- Regression proof: with only the two new tests applied to the exact base, both fail with `[20, 30]` / `[20, 30, 40]` instead of `[10, 30]` / `[10, 30, 50]`
- `npm test -- --runInBand` — 5/5 suites, 123/123 tests, 5/5 snapshots passed
- `npm run tsc` — passed
- `npm run lint` — passed
- `npm run compile` — passed
- `git diff --check` and source Prettier check — passed

The full test run retains the repositorys existing React `act(...)` console warnings; it has no test failures.

## Overlap audit

Open PR #1091 changes `Range.test.tsx` for the independent decimal-distance comparison and places its test in a separate section. #1089 changes drag-completion coverage. The old #1055, #866, and #766 branches touch `Slider.tsx` for deprecated APIs, mark/step memoization, and cursor styling; none changes track-click constraint handling.

## AI assistance disclosure

Codex was used to reproduce the old report on current master, trace the click and offset paths, implement the focused reuse of existing constraints, audit open file overlaps, and run the verification above. I reviewed the diff and results before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
  - 修复点击刻度或轨道时未正确遵循 `pushable` 约束的问题。
  - 确保点击轨道和在可编辑模式下新增滑块后，各滑块之间保持正确间距。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->