### PR TITLE
fix: prevent track focus from scrolling

### DIFF
--- a/src/Handles/index.tsx
+++ b/src/Handles/index.tsx
@@ -26,7 +26,7 @@ export interface HandlesProps {
 }
 
 export interface HandlesRef {
-  focus: (index: number) => void;
+  focus: (index: number, options?: FocusOptions) => void;
   hideHelp: VoidFunction;
 }
 
@@ -66,8 +66,12 @@ const Handles = React.forwardRef<HandlesRef, HandlesProps>((props, ref) => {
 
   // =========================== Render ===========================
   React.useImperativeHandle(ref, () => ({
-    focus: (index: number) => {
-      handlesRef.current[index]?.focus();
+    focus: (index: number, options?: FocusOptions) => {
+      if (options) {
+        handlesRef.current[index]?.focus(options);
+      } else {
+        handlesRef.current[index]?.focus();
+      }
     },
     hideHelp: () => {
       flushSync(() => {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -415,7 +415,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
       if (e) {
         (document.activeElement as HTMLElement)?.blur?.();
-        handlesRef.current!.focus(focusIndex);
+        handlesRef.current!.focus(focusIndex, { preventScroll: true });
         onStartDrag(e, focusIndex, cloneNextValues);
       } else {
         // https://github.com/ant-design/ant-design/issues/49997

--- a/tests/Slider.test.js
+++ b/tests/Slider.test.js
@@ -33,6 +33,17 @@ describe('Slider', () => {
     });
   });
 
+  it('does not scroll the page when focusing a handle from a track press', () => {
+    const { container } = render(<Slider defaultValue={25} />);
+    const slider = container.querySelector('.rc-slider');
+    const handle = container.querySelector('.rc-slider-handle');
+    const focus = jest.spyOn(handle, 'focus');
+
+    fireEvent.mouseDown(slider, { clientX: 50, clientY: 0 });
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
   it('should render Slider correctly where value > startPoint', () => {
     const { container } = render(<Slider value={50} startPoint={20} />);
     expect(container.getElementsByClassName('rc-slider-handle')[0]).toHaveStyle({ left: '50%' });


### PR DESCRIPTION
## Summary

- focus the selected handle with `preventScroll` when a track press starts a drag
- keep the public Slider ref focus path unchanged
- cover the focus options passed by the track interaction

Fixes #1060.

## Verification

- the regression failed on the exact base because `focus()` received no options
- the fixed regression passes
- full test suite: 122/122 tests and 5/5 snapshots
- TypeScript, focused ESLint, Prettier, full ESM/CJS/declaration and Less compilation, and diff checks pass

## Overlap audit

I searched current open issues and pull requests for #1060, `preventScroll`, and scroll-preserving focus. No implementation overlap was found.

AI assistance disclosure: Codex was used to trace the focus path, reproduce the reported behavior at the DOM API boundary, implement the scoped fix and regression, audit overlap, and run validation. The failure and passing results above were verified directly on the exact base and signed head commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 滑块通过轨道或标记改变值并聚焦手柄时，将避免页面自动滚动。
  - 手柄聚焦支持传入可选的聚焦配置。

- **测试**
  - 新增测试，验证通过轨道操作聚焦手柄时页面不会滚动。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->