### PR TITLE
refactor: use renderable guard for marks

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/util": "^1.11.1",
+    "@rc-component/util": "^1.13.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -1,4 +1,10 @@
-import { isEqual, useControlledState, useEvent, warning } from '@rc-component/util';
+import {
+  isEqual,
+  isReactRenderable,
+  useControlledState,
+  useEvent,
+  warning,
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import Handles, { type HandlesProps, type HandlesRef } from './Handles';
@@ -234,7 +240,7 @@ const Slider = React.forwardRef<SliderRef, SliderProps<number | number[]>>((prop
 
         return markObj;
       })
-      .filter(({ label }) => label || typeof label === 'number')
+      .filter(({ label }) => isReactRenderable(label))
       .sort((a, b) => a.value - b.value);
   }, [marks]);
 


### PR DESCRIPTION
## 说明

- 使用 `isReactRenderable` 统一判断 mark label 是否需要渲染
- 保留现有空内容边界，并支持数字 `0`、`NaN` 等有效 React 内容
- 将 `@rc-component/util` 的最低版本提升到首次提供该 helper 的 `^1.13.0`

## 验证

- `npm run tsc`
- `npm test -- --runInBand`
- `git diff --check`

关联 ant-design/ant-design#59193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复滑块刻度标记的显示判断，支持更多可渲染内容作为标记标签。
* **依赖更新**
  * 更新相关工具库版本，提升兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->